### PR TITLE
Refactor app shell, landing, and auth into reusable components and hooks

### DIFF
--- a/docs/codebase-cleanup-plan.md
+++ b/docs/codebase-cleanup-plan.md
@@ -1,0 +1,124 @@
+# Codebase Cleanup & Architecture Plan (TanStack Start)
+
+## Goals
+
+- Remove clearly dead code and stale scaffolding.
+- Reduce route/page file size and duplicate UI logic.
+- Create a cleaner app-shell architecture around `/app` route boundaries.
+- Keep all existing shadcn UI primitives unchanged.
+
+## Current-State Findings
+
+### 1) Large route files and mixed concerns
+
+- `src/routes/index.tsx` is a single large route component with inline content arrays and all sections embedded in one file.
+- `src/routes/app.tsx` handles auth guard logic, shell layout composition, route navigation config, and local panel state in one file.
+
+### 2) Repeated auth form logic
+
+- `src/routes/signin.tsx` and `src/routes/signup.tsx` duplicate state management, form structure, submit lifecycle, and error handling.
+
+### 3) Placeholder route duplication
+
+- `src/routes/app.bookmarks.tsx`, `src/routes/app.collections.tsx`, `src/routes/app.notes.tsx`, and `src/routes/app.settings.tsx` repeat nearly identical placeholder page markup.
+
+### 4) Stale/likely dead backend scaffolding
+
+- Convex schema still includes `products` and `todos` tables that are not used in current frontend routes.
+- `convex/todos.ts` appears to be scaffold code with no current usage from the app.
+
+### 5) Dependency drift / likely unused packages
+
+- `package.json` includes AI-related and store-related packages not referenced in current `src/` and active Convex usage.
+- README still includes scaffold/tutorial content that no longer matches the current product surface.
+
+## Cleanup Plan
+
+## Phase 1 — Safe dead-code and drift cleanup
+
+1. **Remove unused Convex scaffold domain**
+   - Remove `todos` table and `convex/todos.ts` if confirmed unused by product roadmap.
+   - Remove `products` table if also unowned.
+   - Regenerate Convex types after schema cleanup.
+
+2. **Prune unused dependencies**
+   - Build an explicit dependency-usage audit (`rg` + lockfile/package review).
+   - Remove unused AI/store packages only after `npm run build`, `npm run test`, and `npm run lint` remain green.
+
+3. **Documentation alignment**
+   - Replace scaffold README sections (chat/tutorial leftovers) with project-specific setup and architecture overview.
+
+## Phase 2 — Route architecture decomposition
+
+1. **Split `/app` shell into route-local modules**
+   - Keep file route entry minimal in `src/routes/app.tsx`.
+   - Move shell UI pieces into route-local component files, e.g.:
+     - `src/features/app-shell/components/app-header.tsx`
+     - `src/features/app-shell/components/app-sidebar.tsx`
+     - `src/features/app-shell/components/reader-panel.tsx`
+     - `src/features/app-shell/config/navigation.ts`
+   - Keep auth guard in a dedicated wrapper component/hook (single responsibility).
+
+2. **Create lightweight route-level state hooks**
+   - Extract `isReaderOpen` logic into a focused `useReaderPanelState` hook.
+   - Keep state local unless cross-route persistence is required.
+
+3. **Stabilize route contracts**
+   - Define a typed nav item model once and reuse in shell + page metadata.
+
+## Phase 3 — Auth route consolidation
+
+1. **Introduce shared auth form primitives (non-shadcn wrappers)**
+   - Keep existing shadcn primitives untouched.
+   - Add small shared components around repeated label/input/error blocks.
+
+2. **Extract shared submit behavior**
+   - Move common auth submit lifecycle (pending/error/reset) into a reusable hook.
+   - Keep per-route differences explicit (`flow: signIn` vs `signUp`, password min length messaging).
+
+## Phase 4 — Landing page modularization
+
+1. **Break `src/routes/index.tsx` into composable sections**
+   - Keep route file focused on assembly and data imports.
+   - Move sections into focused components:
+     - `landing-header`
+     - `landing-hero`
+     - `landing-features`
+     - `landing-steps`
+     - `landing-faq`
+     - `landing-footer`
+
+2. **Move static content arrays to route-local content module**
+   - Export typed `features`, `steps`, and `faqs` from one module.
+   - Reduce re-renders and improve readability by keeping constants outside component body.
+
+## Phase 5 — Placeholder route simplification
+
+1. **Create a reusable `AppSectionPlaceholder` component**
+   - Replace repeated markup in four app subroutes with a single shared component.
+   - Keep each route file as a thin route declaration + section-specific props.
+
+2. **Optionally consolidate with a route factory only if readability improves**
+   - Prefer explicit route files over over-abstracted dynamic generation.
+
+## Execution Order (recommended)
+
+1. Phase 1 (dead code/deps/docs)
+2. Phase 2 (`/app` shell decomposition)
+3. Phase 3 (auth consolidation)
+4. Phase 4 (landing page split)
+5. Phase 5 (placeholder simplification)
+
+## Definition of Done
+
+- Route files are small and single-purpose.
+- No orphan tables/functions/dependencies remain.
+- Shared auth and placeholder UI logic is deduplicated.
+- README/docs reflect actual product and runtime requirements.
+- `npm run lint`, `npm run test`, and `npm run build` pass after each phase.
+
+## Guardrails
+
+- Do not edit shadcn primitive component implementations under `src/components/ui/*`.
+- Keep generated files (`src/routeTree.gen.ts`, `convex/_generated/*`) out of manual edits.
+- Prefer explicit module boundaries over introducing global state early.

--- a/src/features/app-sections/components/app-section-placeholder.tsx
+++ b/src/features/app-sections/components/app-section-placeholder.tsx
@@ -1,0 +1,23 @@
+type AppSectionPlaceholderProps = {
+  eyebrow: string
+  title: string
+  description?: string
+}
+
+export function AppSectionPlaceholder({
+  eyebrow,
+  title,
+  description = 'Empty page.',
+}: AppSectionPlaceholderProps) {
+  return (
+    <div>
+      <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        {eyebrow}
+      </p>
+      <h1 className="mt-1 text-xl font-semibold leading-tight">{title}</h1>
+      <p className="mt-3 text-xs leading-snug text-muted-foreground">
+        {description}
+      </p>
+    </div>
+  )
+}

--- a/src/features/app-shell/components/app-header.tsx
+++ b/src/features/app-shell/components/app-header.tsx
@@ -1,0 +1,54 @@
+import type { MouseEventHandler } from 'react'
+
+import { Button } from '#/components/ui/button'
+import { Input } from '#/components/ui/input'
+import { SidebarTrigger } from '#/components/ui/sidebar'
+
+type AppHeaderProps = {
+  isReaderOpen: boolean
+  onToggleReaderPanel: MouseEventHandler<HTMLButtonElement>
+  onSignOut: MouseEventHandler<HTMLButtonElement>
+}
+
+export function AppHeader({
+  isReaderOpen,
+  onToggleReaderPanel,
+  onSignOut,
+}: AppHeaderProps) {
+  return (
+    <header className="fixed inset-x-0 top-0 z-40 h-14 border-b border-border/50 bg-background">
+      <div className="flex h-full items-center justify-between gap-2 px-3 sm:px-4">
+        <div className="flex min-w-0 items-center gap-1">
+          <SidebarTrigger className="shrink-0" />
+          <p className="truncate text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            Listit Workspace
+          </p>
+        </div>
+
+        <div className="hidden w-full max-w-md items-center md:flex">
+          <Input
+            aria-label="Global search placeholder"
+            placeholder="Search bookmarks (coming soon)"
+          />
+        </div>
+
+        <div className="flex items-center gap-1">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onToggleReaderPanel}
+          >
+            {isReaderOpen ? 'Hide panel' : 'Show panel'}
+          </Button>
+          <Button type="button" variant="outline" size="sm">
+            Profile
+          </Button>
+          <Button type="button" variant="outline" size="sm" onClick={onSignOut}>
+            Sign out
+          </Button>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/src/features/app-shell/components/app-sidebar.tsx
+++ b/src/features/app-shell/components/app-sidebar.tsx
@@ -1,0 +1,56 @@
+import { Link } from '@tanstack/react-router'
+
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from '#/components/ui/sidebar'
+import { APP_NAV_ITEMS } from '#/features/app-shell/config/navigation'
+
+type AppSidebarProps = {
+  pathname: string
+}
+
+export function AppSidebar({ pathname }: AppSidebarProps) {
+  return (
+    <Sidebar
+      className="top-14 h-[calc(100svh-3.5rem)] border-r border-sidebar-border/80"
+      collapsible="icon"
+    >
+      <SidebarHeader className="gap-1 border-b border-sidebar-border/70 p-2">
+        <p className="px-2 text-[11px] font-medium uppercase tracking-wide text-sidebar-foreground/70">
+          Navigation
+        </p>
+      </SidebarHeader>
+
+      <SidebarContent className="p-1">
+        <SidebarGroup className="px-1 py-1">
+          <SidebarMenu>
+            {APP_NAV_ITEMS.map((item) => (
+              <SidebarMenuItem key={item.to}>
+                <SidebarMenuButton
+                  asChild
+                  size="sm"
+                  tooltip={item.label}
+                  isActive={pathname === item.to}
+                  className="h-7 rounded-full"
+                >
+                  <Link to={item.to} aria-label={item.label}>
+                    <span className="inline-flex size-4 items-center justify-center rounded-sm text-[10px] font-medium">
+                      {item.label.charAt(0)}
+                    </span>
+                    <span>{item.label}</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            ))}
+          </SidebarMenu>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  )
+}

--- a/src/features/app-shell/components/reader-panel.tsx
+++ b/src/features/app-shell/components/reader-panel.tsx
@@ -1,0 +1,16 @@
+export function ReaderPanel() {
+  return (
+    <aside className="hidden w-88 shrink-0 border-l border-border/50 p-4 lg:block">
+      <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        Reader and notes
+      </p>
+      <h2 className="mt-1 text-base font-semibold leading-tight">
+        Preview panel
+      </h2>
+      <p className="mt-3 text-xs leading-snug text-muted-foreground">
+        This optional panel is reserved for bookmark reader content and editable
+        notes.
+      </p>
+    </aside>
+  )
+}

--- a/src/features/app-shell/config/navigation.ts
+++ b/src/features/app-shell/config/navigation.ts
@@ -1,0 +1,11 @@
+export type AppNavigationItem = {
+  label: string
+  to: '/app/bookmarks' | '/app/collections' | '/app/notes' | '/app/settings'
+}
+
+export const APP_NAV_ITEMS: AppNavigationItem[] = [
+  { label: 'Bookmarks', to: '/app/bookmarks' },
+  { label: 'Collections', to: '/app/collections' },
+  { label: 'Notes', to: '/app/notes' },
+  { label: 'Settings', to: '/app/settings' },
+]

--- a/src/features/app-shell/hooks/use-reader-panel-state.ts
+++ b/src/features/app-shell/hooks/use-reader-panel-state.ts
@@ -1,0 +1,14 @@
+import { useState } from 'react'
+
+export function useReaderPanelState(defaultOpen = true) {
+  const [isReaderOpen, setIsReaderOpen] = useState(defaultOpen)
+
+  function toggleReaderPanel() {
+    setIsReaderOpen((previous) => !previous)
+  }
+
+  return {
+    isReaderOpen,
+    toggleReaderPanel,
+  }
+}

--- a/src/features/auth/components/email-password-form.tsx
+++ b/src/features/auth/components/email-password-form.tsx
@@ -1,0 +1,74 @@
+import type { FormEvent } from 'react'
+
+import { Button } from '#/components/ui/button'
+import { Input } from '#/components/ui/input'
+
+type EmailPasswordFormProps = {
+  email: string
+  password: string
+  onEmailChange: (value: string) => void
+  onPasswordChange: (value: string) => void
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void
+  isSubmitting: boolean
+  submitLabel: string
+  submittingLabel: string
+  passwordAutoComplete: 'current-password' | 'new-password'
+  passwordMinLength?: number
+  error?: string | null
+  helperText?: string
+}
+
+export function EmailPasswordForm({
+  email,
+  password,
+  onEmailChange,
+  onPasswordChange,
+  onSubmit,
+  isSubmitting,
+  submitLabel,
+  submittingLabel,
+  passwordAutoComplete,
+  passwordMinLength,
+  error,
+  helperText,
+}: EmailPasswordFormProps) {
+  return (
+    <form className="grid gap-3" onSubmit={onSubmit}>
+      <label className="grid gap-1.5 text-xs">
+        <span className="text-muted-foreground">Email</span>
+        <Input
+          autoComplete="email"
+          inputMode="email"
+          type="email"
+          value={email}
+          onChange={(event) => onEmailChange(event.currentTarget.value)}
+          required
+        />
+      </label>
+
+      <label className="grid gap-1.5 text-xs">
+        <span className="text-muted-foreground">Password</span>
+        <Input
+          autoComplete={passwordAutoComplete}
+          type="password"
+          value={password}
+          onChange={(event) => onPasswordChange(event.currentTarget.value)}
+          minLength={passwordMinLength}
+          required
+        />
+      </label>
+
+      {error ? (
+        <p className="text-xs leading-snug text-destructive">{error}</p>
+      ) : helperText ? (
+        <p className="text-[11px] leading-snug text-muted-foreground">
+          {helperText}
+        </p>
+      ) : null}
+
+      <Button type="submit" size="lg" disabled={isSubmitting}>
+        {isSubmitting ? submittingLabel : submitLabel}
+      </Button>
+    </form>
+  )
+}

--- a/src/features/auth/hooks/use-auth-submit.ts
+++ b/src/features/auth/hooks/use-auth-submit.ts
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+
+type UseAuthSubmitOptions = {
+  onSubmit: () => Promise<void>
+  fallbackError: string
+}
+
+export function useAuthSubmit({
+  onSubmit,
+  fallbackError,
+}: UseAuthSubmitOptions) {
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  async function submitWithState() {
+    setError(null)
+    setIsSubmitting(true)
+
+    try {
+      await onSubmit()
+    } catch (submitError) {
+      setError(
+        submitError instanceof Error ? submitError.message : fallbackError,
+      )
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return {
+    error,
+    isSubmitting,
+    submitWithState,
+  }
+}

--- a/src/features/landing/components/landing-audience.tsx
+++ b/src/features/landing/components/landing-audience.tsx
@@ -1,0 +1,23 @@
+import { AUDIENCES } from '#/features/landing/content'
+
+export function LandingAudience() {
+  return (
+    <section className="border-y border-border/50 py-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          Designed for focus
+        </p>
+        <div className="grid grid-cols-2 gap-x-6 gap-y-2 sm:flex sm:flex-wrap sm:justify-end sm:gap-4">
+          {AUDIENCES.map((label) => (
+            <div
+              key={label}
+              className="text-xs font-medium text-muted-foreground"
+            >
+              {label}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/features/landing/components/landing-cta.tsx
+++ b/src/features/landing/components/landing-cta.tsx
@@ -1,0 +1,24 @@
+import { Link } from '@tanstack/react-router'
+
+import { Button } from '#/components/ui/button'
+
+export function LandingCta() {
+  return (
+    <section id="get-started" className="border-t border-border/50 py-10">
+      <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
+        <div className="max-w-xl">
+          <h2 className="text-base font-semibold leading-tight">
+            Start with one link.
+          </h2>
+          <p className="mt-2 text-xs leading-snug text-muted-foreground">
+            Capture now, read later, and ask questions when you need an answer
+            grounded in your saved sources.
+          </p>
+        </div>
+        <Button asChild size="lg">
+          <Link to="/signup">Get started</Link>
+        </Button>
+      </div>
+    </section>
+  )
+}

--- a/src/features/landing/components/landing-faq.tsx
+++ b/src/features/landing/components/landing-faq.tsx
@@ -1,0 +1,30 @@
+import { FAQS } from '#/features/landing/content'
+
+export function LandingFaq() {
+  return (
+    <section id="faq" className="border-t border-border/50 py-10">
+      <div className="max-w-2xl">
+        <h2 className="text-base font-semibold leading-tight">FAQ</h2>
+        <p className="mt-2 text-xs leading-snug text-muted-foreground">
+          Short answers to the things people ask first.
+        </p>
+      </div>
+
+      <div className="mt-5 grid gap-2">
+        {FAQS.map((item) => (
+          <details
+            key={item.q}
+            className="group rounded-lg border border-border/60 px-4 py-3"
+          >
+            <summary className="cursor-pointer text-xs font-medium leading-tight outline-none focus-visible:ring-2 focus-visible:ring-ring/30">
+              {item.q}
+            </summary>
+            <p className="mt-2 text-xs leading-snug text-muted-foreground">
+              {item.a}
+            </p>
+          </details>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/features/landing/components/landing-features.tsx
+++ b/src/features/landing/components/landing-features.tsx
@@ -1,0 +1,27 @@
+import { FEATURES } from '#/features/landing/content'
+
+export function LandingFeatures() {
+  return (
+    <section id="features" className="py-10">
+      <div className="flex items-baseline justify-between gap-4">
+        <h2 className="text-base font-semibold leading-tight">Features</h2>
+        <p className="text-[11px] text-muted-foreground">
+          Minimal surface area. Strong fundamentals.
+        </p>
+      </div>
+
+      <div className="mt-5 divide-y divide-border/50 border-t border-border/50">
+        {FEATURES.map((feature) => (
+          <div key={feature.title} className="grid gap-1 py-4 sm:grid-cols-12">
+            <div className="text-xs font-semibold leading-tight sm:col-span-4">
+              {feature.title}
+            </div>
+            <div className="text-xs leading-snug text-muted-foreground sm:col-span-8">
+              {feature.description}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/features/landing/components/landing-footer.tsx
+++ b/src/features/landing/components/landing-footer.tsx
@@ -1,0 +1,21 @@
+import { Button } from '#/components/ui/button'
+
+export function LandingFooter() {
+  return (
+    <footer className="border-t border-border/50 py-6">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="text-[11px] text-muted-foreground">
+          © {new Date().getFullYear()} Listit
+        </div>
+        <div className="flex items-center gap-2">
+          <Button asChild variant="ghost" size="sm">
+            <a href="#features">Features</a>
+          </Button>
+          <Button asChild variant="ghost" size="sm">
+            <a href="#faq">FAQ</a>
+          </Button>
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/src/features/landing/components/landing-header.tsx
+++ b/src/features/landing/components/landing-header.tsx
@@ -1,0 +1,39 @@
+import { Link } from '@tanstack/react-router'
+
+import { Button } from '#/components/ui/button'
+
+export function LandingHeader() {
+  return (
+    <header className="border-b border-border/50">
+      <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-4 py-3">
+        <div className="flex items-center gap-2">
+          <div
+            aria-hidden="true"
+            className="grid size-7 place-items-center rounded-md bg-primary text-primary-foreground"
+          >
+            <span className="text-xs font-semibold leading-none">L</span>
+          </div>
+          <span className="text-xs font-semibold leading-none">Listit</span>
+        </div>
+
+        <nav aria-label="Primary" className="flex items-center gap-1">
+          <Button asChild variant="ghost" size="sm">
+            <a href="#features">Features</a>
+          </Button>
+          <Button asChild variant="ghost" size="sm">
+            <a href="#how-it-works">How it works</a>
+          </Button>
+          <Button asChild variant="ghost" size="sm">
+            <a href="#faq">FAQ</a>
+          </Button>
+          <Button asChild size="sm">
+            <Link to="/signup">Sign up</Link>
+          </Button>
+          <Button asChild variant="outline" size="sm">
+            <Link to="/signin">Sign in</Link>
+          </Button>
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/src/features/landing/components/landing-hero.tsx
+++ b/src/features/landing/components/landing-hero.tsx
@@ -1,0 +1,34 @@
+import { Link } from '@tanstack/react-router'
+
+import { Button } from '#/components/ui/button'
+
+export function LandingHero() {
+  return (
+    <section className="py-10">
+      <div className="max-w-2xl">
+        <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          Keyboard-first bookmarking
+        </p>
+        <h1 className="mt-2 text-xl font-semibold leading-tight">
+          Save links fast. Ask later with citations.
+        </h1>
+        <p className="mt-3 text-xs leading-snug text-muted-foreground">
+          Listit is a personal bookmark library with background enrichment and
+          grounded Q&A. Capture a URL, let extraction run, then ask questions
+          backed by your saved sources.
+        </p>
+        <div className="mt-5 flex flex-wrap items-center gap-2">
+          <Button asChild size="lg">
+            <Link to="/signup">Get started</Link>
+          </Button>
+          <Button asChild variant="outline" size="lg">
+            <a href="#how-it-works">See how it works</a>
+          </Button>
+        </div>
+        <p className="mt-3 text-[11px] leading-snug text-muted-foreground">
+          Save first. Enrich in the background. Keep control.
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/src/features/landing/components/landing-steps.tsx
+++ b/src/features/landing/components/landing-steps.tsx
@@ -1,0 +1,30 @@
+import { STEPS } from '#/features/landing/content'
+
+export function LandingSteps() {
+  return (
+    <section id="how-it-works" className="border-t border-border/50 py-10">
+      <div className="max-w-2xl">
+        <h2 className="text-base font-semibold leading-tight">How it works</h2>
+        <p className="mt-2 text-xs leading-snug text-muted-foreground">
+          A simple loop you can repeat daily: save → enrich → ask.
+        </p>
+      </div>
+
+      <div className="mt-5 grid gap-4 sm:grid-cols-3">
+        {STEPS.map((step) => (
+          <div key={step.n} className="border-t border-border/50 pt-4">
+            <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+              {step.n}
+            </div>
+            <div className="mt-2 text-xs font-semibold leading-tight">
+              {step.title}
+            </div>
+            <div className="mt-1 text-xs leading-snug text-muted-foreground">
+              {step.description}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/features/landing/content.ts
+++ b/src/features/landing/content.ts
@@ -1,0 +1,65 @@
+export const FEATURES = [
+  {
+    title: 'Instant capture',
+    description:
+      'Save a URL in seconds. It appears immediately while extraction runs in the background.',
+  },
+  {
+    title: 'Dedup + organization',
+    description:
+      'Canonical URL dedup, manual tags, and collections. Keep your library clean and browsable.',
+  },
+  {
+    title: 'Reader + notes',
+    description:
+      'Reader view with extracted text and per-bookmark notes you can edit and keep.',
+  },
+  {
+    title: 'Ask my bookmarks',
+    description:
+      'Get grounded answers with citations to the exact bookmarks (and notes) that support them.',
+  },
+] as const
+
+export const STEPS = [
+  {
+    n: '01',
+    title: 'Save',
+    description:
+      'Paste a link, hit enter. The bookmark shows up instantly as pending extraction.',
+  },
+  {
+    n: '02',
+    title: 'Enrich',
+    description:
+      'Background extraction pulls text; AI suggests tags/topics and collections—nothing forced.',
+  },
+  {
+    n: '03',
+    title: 'Ask',
+    description:
+      'Ask questions across your saved links and get answers grounded in retrieved chunks with citations.',
+  },
+] as const
+
+export const FAQS = [
+  {
+    q: 'Who is this for?',
+    a: 'Solo users who want a keyboard-driven bookmarking system with trustworthy retrieval later.',
+  },
+  {
+    q: 'Do I need AI features turned on?',
+    a: 'No. You can save and organize manually. Auto-organization and auto notes are optional enhancements.',
+  },
+  {
+    q: 'What’s in scope for MVP?',
+    a: 'URL capture with dedup, tags/collections, background extraction, reader view + notes, and “Ask my bookmarks” with citations.',
+  },
+] as const
+
+export const AUDIENCES = [
+  'Researchers',
+  'Students',
+  'Founders',
+  'Indie builders',
+] as const

--- a/src/routes/app.bookmarks.tsx
+++ b/src/routes/app.bookmarks.tsx
@@ -1,17 +1,11 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute("/app/bookmarks")({
+import { AppSectionPlaceholder } from '#/features/app-sections/components/app-section-placeholder'
+
+export const Route = createFileRoute('/app/bookmarks')({
   component: BookmarksPage,
 })
 
 function BookmarksPage() {
-  return (
-    <div>
-      <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-        Bookmarks
-      </p>
-      <h1 className="mt-1 text-xl font-semibold leading-tight">Bookmarks</h1>
-      <p className="mt-3 text-xs leading-snug text-muted-foreground">Empty page.</p>
-    </div>
-  )
+  return <AppSectionPlaceholder eyebrow="Bookmarks" title="Bookmarks" />
 }

--- a/src/routes/app.collections.tsx
+++ b/src/routes/app.collections.tsx
@@ -1,17 +1,11 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute("/app/collections")({
+import { AppSectionPlaceholder } from '#/features/app-sections/components/app-section-placeholder'
+
+export const Route = createFileRoute('/app/collections')({
   component: CollectionsPage,
 })
 
 function CollectionsPage() {
-  return (
-    <div>
-      <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-        Collections
-      </p>
-      <h1 className="mt-1 text-xl font-semibold leading-tight">Collections</h1>
-      <p className="mt-3 text-xs leading-snug text-muted-foreground">Empty page.</p>
-    </div>
-  )
+  return <AppSectionPlaceholder eyebrow="Collections" title="Collections" />
 }

--- a/src/routes/app.index.tsx
+++ b/src/routes/app.index.tsx
@@ -1,19 +1,17 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute("/app/")({
+import { AppSectionPlaceholder } from '#/features/app-sections/components/app-section-placeholder'
+
+export const Route = createFileRoute('/app/')({
   component: AppIndexPage,
 })
 
 function AppIndexPage() {
   return (
-    <div>
-      <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-        Workspace
-      </p>
-      <h1 className="mt-1 text-xl font-semibold leading-tight">App home</h1>
-      <p className="mt-3 text-xs leading-snug text-muted-foreground">
-        Choose a section from the sidebar.
-      </p>
-    </div>
+    <AppSectionPlaceholder
+      eyebrow="Workspace"
+      title="App home"
+      description="Choose a section from the sidebar."
+    />
   )
 }

--- a/src/routes/app.notes.tsx
+++ b/src/routes/app.notes.tsx
@@ -1,17 +1,11 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute("/app/notes")({
+import { AppSectionPlaceholder } from '#/features/app-sections/components/app-section-placeholder'
+
+export const Route = createFileRoute('/app/notes')({
   component: NotesPage,
 })
 
 function NotesPage() {
-  return (
-    <div>
-      <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-        Notes
-      </p>
-      <h1 className="mt-1 text-xl font-semibold leading-tight">Notes</h1>
-      <p className="mt-3 text-xs leading-snug text-muted-foreground">Empty page.</p>
-    </div>
-  )
+  return <AppSectionPlaceholder eyebrow="Notes" title="Notes" />
 }

--- a/src/routes/app.settings.tsx
+++ b/src/routes/app.settings.tsx
@@ -1,17 +1,11 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute } from '@tanstack/react-router'
 
-export const Route = createFileRoute("/app/settings")({
+import { AppSectionPlaceholder } from '#/features/app-sections/components/app-section-placeholder'
+
+export const Route = createFileRoute('/app/settings')({
   component: SettingsPage,
 })
 
 function SettingsPage() {
-  return (
-    <div>
-      <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-        Settings
-      </p>
-      <h1 className="mt-1 text-xl font-semibold leading-tight">Settings</h1>
-      <p className="mt-3 text-xs leading-snug text-muted-foreground">Empty page.</p>
-    </div>
-  )
+  return <AppSectionPlaceholder eyebrow="Settings" title="Settings" />
 }

--- a/src/routes/app.tsx
+++ b/src/routes/app.tsx
@@ -1,32 +1,29 @@
-import { createFileRoute, Link, Navigate, Outlet, useRouterState } from "@tanstack/react-router"
-import { useState } from "react"
-import { useAuthActions } from "@convex-dev/auth/react"
-import { useConvexAuth } from "convex/react"
-
-import { Button } from "#/components/ui/button"
-import { Input } from "#/components/ui/input"
-import { TooltipProvider } from "#/components/ui/tooltip"
 import {
-  Sidebar,
-  SidebarContent,
-  SidebarGroup,
-  SidebarHeader,
-  SidebarInset,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-  SidebarProvider,
-  SidebarTrigger,
-} from "#/components/ui/sidebar"
+  createFileRoute,
+  Link,
+  Navigate,
+  Outlet,
+  useRouterState,
+} from '@tanstack/react-router'
+import { useAuthActions } from '@convex-dev/auth/react'
+import { useConvexAuth } from 'convex/react'
 
-export const Route = createFileRoute("/app")({
+import { Button } from '#/components/ui/button'
+import { SidebarInset, SidebarProvider } from '#/components/ui/sidebar'
+import { TooltipProvider } from '#/components/ui/tooltip'
+import { AppHeader } from '#/features/app-shell/components/app-header'
+import { AppSidebar } from '#/features/app-shell/components/app-sidebar'
+import { ReaderPanel } from '#/features/app-shell/components/reader-panel'
+import { useReaderPanelState } from '#/features/app-shell/hooks/use-reader-panel-state'
+
+export const Route = createFileRoute('/app')({
   component: AppHome,
 })
 
 function AppHome() {
   const { signOut } = useAuthActions()
   const { isAuthenticated, isLoading } = useConvexAuth()
-  const [isReaderOpen, setIsReaderOpen] = useState(true)
+  const { isReaderOpen, toggleReaderPanel } = useReaderPanelState(true)
   const pathname = useRouterState({
     select: (state) => state.location.pathname,
   })
@@ -35,88 +32,18 @@ function AppHome() {
     return <Navigate to="/signin" />
   }
 
-  const sidebarItems = [
-    { label: "Bookmarks", to: "/app/bookmarks" as const },
-    { label: "Collections", to: "/app/collections" as const },
-    { label: "Notes", to: "/app/notes" as const },
-    { label: "Settings", to: "/app/settings" as const },
-  ]
-
   return (
     <TooltipProvider>
       <SidebarProvider>
         <div className="min-h-dvh bg-background text-foreground">
-          <header className="fixed inset-x-0 top-0 z-40 h-14 border-b border-border/50 bg-background">
-            <div className="flex h-full items-center justify-between gap-2 px-3 sm:px-4">
-              <div className="flex min-w-0 items-center gap-1">
-                <SidebarTrigger className="shrink-0" />
-                <p className="truncate text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-                  Listit Workspace
-                </p>
-              </div>
-
-              <div className="hidden w-full max-w-md items-center md:flex">
-                <Input
-                  aria-label="Global search placeholder"
-                  placeholder="Search bookmarks (coming soon)"
-                />
-              </div>
-
-              <div className="flex items-center gap-1">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setIsReaderOpen((prev) => !prev)}
-                >
-                  {isReaderOpen ? "Hide panel" : "Show panel"}
-                </Button>
-                <Button type="button" variant="outline" size="sm">
-                  Profile
-                </Button>
-                <Button type="button" variant="outline" size="sm" onClick={() => signOut()}>
-                  Sign out
-                </Button>
-              </div>
-            </div>
-          </header>
+          <AppHeader
+            isReaderOpen={isReaderOpen}
+            onToggleReaderPanel={toggleReaderPanel}
+            onSignOut={() => signOut()}
+          />
 
           <div className="flex min-h-dvh pt-14">
-            <Sidebar
-              className="top-14 h-[calc(100svh-3.5rem)] border-r border-sidebar-border/80"
-              collapsible="icon"
-            >
-              <SidebarHeader className="gap-1 border-b border-sidebar-border/70 p-2">
-                <p className="px-2 text-[11px] font-medium uppercase tracking-wide text-sidebar-foreground/70">
-                  Navigation
-                </p>
-              </SidebarHeader>
-
-              <SidebarContent className="p-1">
-                <SidebarGroup className="px-1 py-1">
-                  <SidebarMenu>
-                    {sidebarItems.map((item) => (
-                      <SidebarMenuItem key={item.to}>
-                        <SidebarMenuButton
-                          asChild
-                          size="sm"
-                          tooltip={item.label}
-                          isActive={pathname === item.to}
-                          className="h-7 rounded-full"
-                        >
-                          <Link to={item.to} aria-label={item.label}>
-                            <span className="inline-flex size-4 items-center justify-center rounded-sm text-[10px] font-medium">
-                              {item.label.charAt(0)}
-                            </span>
-                            <span>{item.label}</span>
-                          </Link>
-                        </SidebarMenuButton>
-                      </SidebarMenuItem>
-                    ))}
-                  </SidebarMenu>
-                </SidebarGroup>
-              </SidebarContent>
-            </Sidebar>
+            <AppSidebar pathname={pathname} />
 
             <SidebarInset className="min-w-0">
               <div className="flex min-h-[calc(100dvh-3.5rem)]">
@@ -132,18 +59,7 @@ function AppHome() {
                   </div>
                 </section>
 
-                {isReaderOpen ? (
-                  <aside className="hidden w-88 shrink-0 border-l border-border/50 p-4 lg:block">
-                    <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-                      Reader and notes
-                    </p>
-                    <h2 className="mt-1 text-base font-semibold leading-tight">Preview panel</h2>
-                    <p className="mt-3 text-xs leading-snug text-muted-foreground">
-                      This optional panel is reserved for bookmark reader content and editable
-                      notes.
-                    </p>
-                  </aside>
-                ) : null}
+                {isReaderOpen ? <ReaderPanel /> : null}
               </div>
             </SidebarInset>
           </div>
@@ -152,4 +68,3 @@ function AppHome() {
     </TooltipProvider>
   )
 }
-

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,260 +1,29 @@
-import { Link, createFileRoute } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 
-import { Button } from '#/components/ui/button'
+import { LandingAudience } from '#/features/landing/components/landing-audience'
+import { LandingCta } from '#/features/landing/components/landing-cta'
+import { LandingFaq } from '#/features/landing/components/landing-faq'
+import { LandingFeatures } from '#/features/landing/components/landing-features'
+import { LandingFooter } from '#/features/landing/components/landing-footer'
+import { LandingHeader } from '#/features/landing/components/landing-header'
+import { LandingHero } from '#/features/landing/components/landing-hero'
+import { LandingSteps } from '#/features/landing/components/landing-steps'
 
 export const Route = createFileRoute('/')({ component: Home })
 
 function Home() {
-  const features = [
-    {
-      title: 'Instant capture',
-      description:
-        'Save a URL in seconds. It appears immediately while extraction runs in the background.',
-    },
-    {
-      title: 'Dedup + organization',
-      description:
-        'Canonical URL dedup, manual tags, and collections. Keep your library clean and browsable.',
-    },
-    {
-      title: 'Reader + notes',
-      description:
-        'Reader view with extracted text and per-bookmark notes you can edit and keep.',
-    },
-    {
-      title: 'Ask my bookmarks',
-      description:
-        'Get grounded answers with citations to the exact bookmarks (and notes) that support them.',
-    },
-  ] as const
-
-  const steps = [
-    {
-      n: '01',
-      title: 'Save',
-      description:
-        'Paste a link, hit enter. The bookmark shows up instantly as pending extraction.',
-    },
-    {
-      n: '02',
-      title: 'Enrich',
-      description:
-        'Background extraction pulls text; AI suggests tags/topics and collections—nothing forced.',
-    },
-    {
-      n: '03',
-      title: 'Ask',
-      description:
-        'Ask questions across your saved links and get answers grounded in retrieved chunks with citations.',
-    },
-  ] as const
-
-  const faqs = [
-    {
-      q: 'Who is this for?',
-      a: 'Solo users who want a keyboard-driven bookmarking system with trustworthy retrieval later.',
-    },
-    {
-      q: 'Do I need AI features turned on?',
-      a: 'No. You can save and organize manually. Auto-organization and auto notes are optional enhancements.',
-    },
-    {
-      q: 'What’s in scope for MVP?',
-      a: 'URL capture with dedup, tags/collections, background extraction, reader view + notes, and “Ask my bookmarks” with citations.',
-    },
-  ] as const
-
   return (
     <div className="min-h-dvh bg-background text-foreground">
-      <header className="border-b border-border/50">
-        <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-4 py-3">
-          <div className="flex items-center gap-2">
-            <div
-              aria-hidden="true"
-              className="grid size-7 place-items-center rounded-md bg-primary text-primary-foreground"
-            >
-              <span className="text-xs font-semibold leading-none">L</span>
-            </div>
-            <span className="text-xs font-semibold leading-none">Listit</span>
-          </div>
-
-          <nav aria-label="Primary" className="flex items-center gap-1">
-            <Button asChild variant="ghost" size="sm">
-              <a href="#features">Features</a>
-            </Button>
-            <Button asChild variant="ghost" size="sm">
-              <a href="#how-it-works">How it works</a>
-            </Button>
-            <Button asChild variant="ghost" size="sm">
-              <a href="#faq">FAQ</a>
-            </Button>
-            <Button asChild size="sm">
-              <Link to="/signup">Sign up</Link>
-            </Button>
-            <Button asChild variant="outline" size="sm">
-              <Link to="/signin">Sign in</Link>
-            </Button>
-          </nav>
-        </div>
-      </header>
+      <LandingHeader />
 
       <main className="mx-auto w-full max-w-5xl px-4">
-        <section className="py-10">
-          <div className="max-w-2xl">
-            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-              Keyboard-first bookmarking
-            </p>
-            <h1 className="mt-2 text-xl font-semibold leading-tight">
-              Save links fast. Ask later with citations.
-            </h1>
-            <p className="mt-3 text-xs leading-snug text-muted-foreground">
-              Listit is a personal bookmark library with background enrichment
-              and grounded Q&A. Capture a URL, let extraction run, then ask
-              questions backed by your saved sources.
-            </p>
-            <div className="mt-5 flex flex-wrap items-center gap-2">
-              <Button asChild size="lg">
-                <Link to="/signup">Get started</Link>
-              </Button>
-              <Button asChild variant="outline" size="lg">
-                <a href="#how-it-works">See how it works</a>
-              </Button>
-            </div>
-            <p className="mt-3 text-[11px] leading-snug text-muted-foreground">
-              Save first. Enrich in the background. Keep control.
-            </p>
-          </div>
-        </section>
-
-        <section className="border-y border-border/50 py-6">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-              Designed for focus
-            </p>
-            <div className="grid grid-cols-2 gap-x-6 gap-y-2 sm:flex sm:flex-wrap sm:justify-end sm:gap-4">
-              {['Researchers', 'Students', 'Founders', 'Indie builders'].map(
-                (label) => (
-                  <div
-                    key={label}
-                    className="text-xs font-medium text-muted-foreground"
-                  >
-                    {label}
-                  </div>
-                )
-              )}
-            </div>
-          </div>
-        </section>
-
-        <section id="features" className="py-10">
-          <div className="flex items-baseline justify-between gap-4">
-            <h2 className="text-base font-semibold leading-tight">Features</h2>
-            <p className="text-[11px] text-muted-foreground">
-              Minimal surface area. Strong fundamentals.
-            </p>
-          </div>
-
-          <div className="mt-5 divide-y divide-border/50 border-t border-border/50">
-            {features.map((f) => (
-              <div key={f.title} className="grid gap-1 py-4 sm:grid-cols-12">
-                <div className="text-xs font-semibold leading-tight sm:col-span-4">
-                  {f.title}
-                </div>
-                <div className="text-xs leading-snug text-muted-foreground sm:col-span-8">
-                  {f.description}
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section
-          id="how-it-works"
-          className="border-t border-border/50 py-10"
-        >
-          <div className="max-w-2xl">
-            <h2 className="text-base font-semibold leading-tight">
-              How it works
-            </h2>
-            <p className="mt-2 text-xs leading-snug text-muted-foreground">
-              A simple loop you can repeat daily: save → enrich → ask.
-            </p>
-          </div>
-
-          <div className="mt-5 grid gap-4 sm:grid-cols-3">
-            {steps.map((s) => (
-              <div key={s.n} className="border-t border-border/50 pt-4">
-                <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-                  {s.n}
-                </div>
-                <div className="mt-2 text-xs font-semibold leading-tight">
-                  {s.title}
-                </div>
-                <div className="mt-1 text-xs leading-snug text-muted-foreground">
-                  {s.description}
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section id="faq" className="border-t border-border/50 py-10">
-          <div className="max-w-2xl">
-            <h2 className="text-base font-semibold leading-tight">FAQ</h2>
-            <p className="mt-2 text-xs leading-snug text-muted-foreground">
-              Short answers to the things people ask first.
-            </p>
-          </div>
-
-          <div className="mt-5 grid gap-2">
-            {faqs.map((item) => (
-              <details
-                key={item.q}
-                className="group rounded-lg border border-border/60 px-4 py-3"
-              >
-                <summary className="cursor-pointer text-xs font-medium leading-tight outline-none focus-visible:ring-2 focus-visible:ring-ring/30">
-                  {item.q}
-                </summary>
-                <p className="mt-2 text-xs leading-snug text-muted-foreground">
-                  {item.a}
-                </p>
-              </details>
-            ))}
-          </div>
-        </section>
-
-        <section id="get-started" className="border-t border-border/50 py-10">
-          <div className="flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-center">
-            <div className="max-w-xl">
-              <h2 className="text-base font-semibold leading-tight">
-                Start with one link.
-              </h2>
-              <p className="mt-2 text-xs leading-snug text-muted-foreground">
-                Capture now, read later, and ask questions when you need an
-                answer grounded in your saved sources.
-              </p>
-            </div>
-            <Button asChild size="lg">
-              <Link to="/signup">Get started</Link>
-            </Button>
-          </div>
-        </section>
-
-        <footer className="border-t border-border/50 py-6">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-            <div className="text-[11px] text-muted-foreground">
-              © {new Date().getFullYear()} Listit
-            </div>
-            <div className="flex items-center gap-2">
-              <Button asChild variant="ghost" size="sm">
-                <a href="#features">Features</a>
-              </Button>
-              <Button asChild variant="ghost" size="sm">
-                <a href="#faq">FAQ</a>
-              </Button>
-            </div>
-          </div>
-        </footer>
+        <LandingHero />
+        <LandingAudience />
+        <LandingFeatures />
+        <LandingSteps />
+        <LandingFaq />
+        <LandingCta />
+        <LandingFooter />
       </main>
     </div>
   )

--- a/src/routes/signin.tsx
+++ b/src/routes/signin.tsx
@@ -1,48 +1,40 @@
-import { useState } from "react"
-import { createFileRoute, Navigate } from "@tanstack/react-router"
-import { useAuthActions } from "@convex-dev/auth/react"
-import { useConvexAuth } from "convex/react"
+import { useState, type FormEvent } from 'react'
+import { createFileRoute, Navigate } from '@tanstack/react-router'
+import { useAuthActions } from '@convex-dev/auth/react'
+import { useConvexAuth } from 'convex/react'
 
-import { AuthShell } from "#/components/auth/auth-shell"
-import { Button } from "#/components/ui/button"
-import { Input } from "#/components/ui/input"
+import { AuthShell } from '#/components/auth/auth-shell'
+import { EmailPasswordForm } from '#/features/auth/components/email-password-form'
+import { useAuthSubmit } from '#/features/auth/hooks/use-auth-submit'
 
-export const Route = createFileRoute("/signin")({
+export const Route = createFileRoute('/signin')({
   component: SignInPage,
 })
 
 function SignInPage() {
   const { signIn } = useAuthActions()
   const { isAuthenticated, isLoading } = useConvexAuth()
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
-  const [error, setError] = useState<string | null>(null)
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const { error, isSubmitting, submitWithState } = useAuthSubmit({
+    onSubmit: async () => {
+      await signIn('password', {
+        email,
+        password,
+        flow: 'signIn',
+      })
+    },
+    fallbackError: 'Unable to sign in. Please try again.',
+  })
 
   if (!isLoading && isAuthenticated) {
     return <Navigate to="/app" />
   }
 
-  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    setError(null)
-    setIsSubmitting(true)
-
-    try {
-      await signIn("password", {
-        email,
-        password,
-        flow: "signIn",
-      })
-    } catch (submitError) {
-      setError(
-        submitError instanceof Error
-          ? submitError.message
-          : "Unable to sign in. Please try again."
-      )
-    } finally {
-      setIsSubmitting(false)
-    }
+    await submitWithState()
   }
 
   return (
@@ -53,38 +45,18 @@ function SignInPage() {
       switchCta="Create one"
       switchTo="/signup"
     >
-      <form className="grid gap-3" onSubmit={onSubmit}>
-        <label className="grid gap-1.5 text-xs">
-          <span className="text-muted-foreground">Email</span>
-          <Input
-            autoComplete="email"
-            inputMode="email"
-            type="email"
-            value={email}
-            onChange={(event) => setEmail(event.currentTarget.value)}
-            required
-          />
-        </label>
-
-        <label className="grid gap-1.5 text-xs">
-          <span className="text-muted-foreground">Password</span>
-          <Input
-            autoComplete="current-password"
-            type="password"
-            value={password}
-            onChange={(event) => setPassword(event.currentTarget.value)}
-            required
-          />
-        </label>
-
-        {error ? (
-          <p className="text-xs leading-snug text-destructive">{error}</p>
-        ) : null}
-
-        <Button type="submit" size="lg" disabled={isSubmitting}>
-          {isSubmitting ? "Signing in..." : "Sign in"}
-        </Button>
-      </form>
+      <EmailPasswordForm
+        email={email}
+        password={password}
+        onEmailChange={setEmail}
+        onPasswordChange={setPassword}
+        onSubmit={onSubmit}
+        isSubmitting={isSubmitting}
+        submitLabel="Sign in"
+        submittingLabel="Signing in..."
+        passwordAutoComplete="current-password"
+        error={error}
+      />
     </AuthShell>
   )
 }

--- a/src/routes/signup.tsx
+++ b/src/routes/signup.tsx
@@ -1,48 +1,40 @@
-import { useState } from "react"
-import { createFileRoute, Navigate } from "@tanstack/react-router"
-import { useAuthActions } from "@convex-dev/auth/react"
-import { useConvexAuth } from "convex/react"
+import { useState, type FormEvent } from 'react'
+import { createFileRoute, Navigate } from '@tanstack/react-router'
+import { useAuthActions } from '@convex-dev/auth/react'
+import { useConvexAuth } from 'convex/react'
 
-import { AuthShell } from "#/components/auth/auth-shell"
-import { Button } from "#/components/ui/button"
-import { Input } from "#/components/ui/input"
+import { AuthShell } from '#/components/auth/auth-shell'
+import { EmailPasswordForm } from '#/features/auth/components/email-password-form'
+import { useAuthSubmit } from '#/features/auth/hooks/use-auth-submit'
 
-export const Route = createFileRoute("/signup")({
+export const Route = createFileRoute('/signup')({
   component: SignUpPage,
 })
 
 function SignUpPage() {
   const { signIn } = useAuthActions()
   const { isAuthenticated, isLoading } = useConvexAuth()
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
-  const [error, setError] = useState<string | null>(null)
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+
+  const { error, isSubmitting, submitWithState } = useAuthSubmit({
+    onSubmit: async () => {
+      await signIn('password', {
+        email,
+        password,
+        flow: 'signUp',
+      })
+    },
+    fallbackError: 'Unable to create account. Please try again.',
+  })
 
   if (!isLoading && isAuthenticated) {
     return <Navigate to="/app" />
   }
 
-  async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+  async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    setError(null)
-    setIsSubmitting(true)
-
-    try {
-      await signIn("password", {
-        email,
-        password,
-        flow: "signUp",
-      })
-    } catch (submitError) {
-      setError(
-        submitError instanceof Error
-          ? submitError.message
-          : "Unable to create account. Please try again."
-      )
-    } finally {
-      setIsSubmitting(false)
-    }
+    await submitWithState()
   }
 
   return (
@@ -53,43 +45,20 @@ function SignUpPage() {
       switchCta="Sign in"
       switchTo="/signin"
     >
-      <form className="grid gap-3" onSubmit={onSubmit}>
-        <label className="grid gap-1.5 text-xs">
-          <span className="text-muted-foreground">Email</span>
-          <Input
-            autoComplete="email"
-            inputMode="email"
-            type="email"
-            value={email}
-            onChange={(event) => setEmail(event.currentTarget.value)}
-            required
-          />
-        </label>
-
-        <label className="grid gap-1.5 text-xs">
-          <span className="text-muted-foreground">Password</span>
-          <Input
-            autoComplete="new-password"
-            type="password"
-            value={password}
-            onChange={(event) => setPassword(event.currentTarget.value)}
-            minLength={8}
-            required
-          />
-        </label>
-
-        {error ? (
-          <p className="text-xs leading-snug text-destructive">{error}</p>
-        ) : (
-          <p className="text-[11px] leading-snug text-muted-foreground">
-            Use at least 8 characters for a stronger password.
-          </p>
-        )}
-
-        <Button type="submit" size="lg" disabled={isSubmitting}>
-          {isSubmitting ? "Creating account..." : "Create account"}
-        </Button>
-      </form>
+      <EmailPasswordForm
+        email={email}
+        password={password}
+        onEmailChange={setEmail}
+        onPasswordChange={setPassword}
+        onSubmit={onSubmit}
+        isSubmitting={isSubmitting}
+        submitLabel="Create account"
+        submittingLabel="Creating account..."
+        passwordAutoComplete="new-password"
+        passwordMinLength={8}
+        error={error}
+        helperText="Use at least 8 characters for a stronger password."
+      />
     </AuthShell>
   )
 }


### PR DESCRIPTION
### Motivation

- Reduce duplication and large route files by extracting repeated UI and content into focused components and modules. 
- Create a clearer app-shell boundary with small route entry files and dedicated UI primitives for header, sidebar, and reader panel. 
- Consolidate repeated auth form logic into reusable form and submit-state primitives to centralize behavior and improve maintainability.

### Description

- Added an architecture plan `docs/codebase-cleanup-plan.md` describing cleanup phases and goals. 
- Extracted the app shell UI into `#features/app-shell`: `app-header.tsx`, `app-sidebar.tsx`, `reader-panel.tsx`, `config/navigation.ts`, and a `use-reader-panel-state` hook, and updated `src/routes/app.tsx` to use these. 
- Introduced a shared `AppSectionPlaceholder` component and replaced repeated placeholder markup in `/app` subroutes (`app.bookmarks`, `app.collections`, `app.notes`, `app.settings`, `app.index`). 
- Split the landing page into composable components under `#features/landing` and moved static content into `#features/landing/content.ts` (`landing-header`, `landing-hero`, `landing-audience`, `landing-features`, `landing-steps`, `landing-faq`, `landing-cta`, `landing-footer`), and updated `src/routes/index.tsx` to assemble them. 
- Consolidated auth UI and behavior into `#features/auth`: `email-password-form.tsx` and `use-auth-submit.ts`, and refactored `src/routes/signin.tsx` and `src/routes/signup.tsx` to use these shared primitives. 
- Minor import/style cleanups (consistent single-quote imports) and type refinements for navigation items and hook signatures.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec97beb5cc8321b9cbf1b85122dbce)