### PR TITLE
Implement quick URL capture in the workspace

### DIFF
--- a/src/convex/bookmarks.ts
+++ b/src/convex/bookmarks.ts
@@ -54,10 +54,10 @@ export const saveUrl = mutation({
 				updatedAt: now,
 				lastSavedAt: now
 			});
-			return existing._id;
+			return { bookmarkId: existing._id, created: false };
 		}
 
-		return await ctx.db.insert('bookmarks', {
+		const bookmarkId = await ctx.db.insert('bookmarks', {
 			userId,
 			url: args.url.trim(),
 			normalizedUrl,
@@ -73,6 +73,7 @@ export const saveUrl = mutation({
 			updatedAt: now,
 			lastSavedAt: now
 		});
+		return { bookmarkId, created: true };
 	}
 });
 
@@ -104,7 +105,10 @@ export const list = query({
 					Boolean(bookmark && bookmark.userId === userId)
 				)
 				.filter((bookmark) => !args.collectionId || bookmark.collectionId === args.collectionId)
-				.sort((left, right) => right.createdAt - left.createdAt);
+				.sort(
+					(left, right) =>
+						(right.lastSavedAt ?? right.createdAt) - (left.lastSavedAt ?? left.createdAt)
+				);
 			return await withLibraryData(ctx, filtered);
 		}
 
@@ -116,7 +120,11 @@ export const list = query({
 					)
 			: ctx.db.query('bookmarks').withIndex('by_user_created', (q) => q.eq('userId', userId));
 
-		return await withLibraryData(ctx, await base.order('desc').collect());
+		const bookmarks = await base.collect();
+		bookmarks.sort(
+			(left, right) => (right.lastSavedAt ?? right.createdAt) - (left.lastSavedAt ?? left.createdAt)
+		);
+		return await withLibraryData(ctx, bookmarks);
 	}
 });
 

--- a/src/convex/helpers.ts
+++ b/src/convex/helpers.ts
@@ -56,7 +56,8 @@ export async function requireOwnedTag(ctx: AuthedCtx, tagId: Id<'tags'>) {
 }
 
 export function normalizeUrl(input: string) {
-	const parsed = new URL(input.trim());
+	const trimmed = input.trim();
+	const parsed = new URL(/^[a-z][a-z\d+\-.]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`);
 	parsed.protocol = parsed.protocol.toLowerCase();
 	parsed.hostname = parsed.hostname.toLowerCase();
 	parsed.hash = '';

--- a/src/routes/(app)/app/+page.svelte
+++ b/src/routes/(app)/app/+page.svelte
@@ -32,6 +32,7 @@
 	const rows = $derived((bookmarksResponse.data ?? []) as BookmarkRow[]);
 	let selectedBookmarkId = $state<string | null>(null);
 	let url = $state('');
+	let saveSuccess = $state('');
 	let saveError = $state('');
 	let isSaving = $state(false);
 
@@ -75,14 +76,23 @@
 		if (!trimmedUrl) return;
 
 		isSaving = true;
+		saveSuccess = '';
 		saveError = '';
 
 		try {
-			const bookmarkId = await convexClient.mutation(api.bookmarks.saveUrl, { url: trimmedUrl });
-			selectedBookmarkId = bookmarkId;
+			const result = await convexClient.mutation(api.bookmarks.saveUrl, { url: trimmedUrl });
+			selectedBookmarkId = result.bookmarkId;
 			url = '';
+			saveSuccess = result.created
+				? 'Saved. Extraction is pending.'
+				: 'Already saved. Moved to the top.';
 		} catch (error) {
-			saveError = error instanceof Error ? error.message : 'Could not save this URL.';
+			saveError =
+				error instanceof Error && error.message.includes('Invalid URL')
+					? 'Enter a valid URL or domain.'
+					: error instanceof Error
+						? error.message
+						: 'Could not save this URL.';
 		} finally {
 			isSaving = false;
 		}
@@ -115,7 +125,8 @@
 					<InputGroup.InputGroupInput
 						bind:value={url}
 						placeholder="Paste a URL to save it..."
-						type="url"
+						type="text"
+						inputmode="url"
 						disabled={isSaving}
 					/>
 					<InputGroup.InputGroupButton type="submit" size="sm" disabled={isSaving || !url.trim()}>
@@ -124,6 +135,8 @@
 				</InputGroup.InputGroup>
 				{#if saveError}
 					<p class="mt-2 text-xs text-destructive">{saveError}</p>
+				{:else if saveSuccess}
+					<p class="mt-2 text-xs text-muted-foreground">{saveSuccess}</p>
 				{/if}
 			</form>
 		</div>


### PR DESCRIPTION
## Summary
- Updated bookmark capture to return whether a save created a new record or reused an existing one.
- Allowed bare-domain input by normalizing missing schemes to `https://` before parsing.
- Reordered the library by latest save activity so deduped captures move to the top.
- Added inline success/error feedback in the workspace capture form and kept saved bookmarks selected immediately.

## Testing
- `npm run check` passed.
- Svelte autofix validation on `src/routes/(app)/app/+page.svelte` passed with no issues.
- Manual flow covered: new URL save, deduped save, and bare-domain input handling.