### PR TITLE
Connect collections to the app UI

### DIFF
--- a/docs/lit-23-collections-ui-prd.md
+++ b/docs/lit-23-collections-ui-prd.md
@@ -1,0 +1,56 @@
+## Problem Statement
+
+ListIt supports collections in the backend, but the app UI still shows placeholder collection data. Users need a real collection management flow inside the workspace so they can organize bookmarks without leaving the library view.
+
+## Solution
+
+Connect the existing Convex collection functions to the app shell. Users can create, list, rename, delete, and filter by collections from the sidebar. Users can assign the selected bookmark to a real collection from the bookmark details pane.
+
+## User Stories
+
+1. As a ListIt user, I want to see my real collections in the workspace sidebar, so that navigation reflects my saved organization.
+2. As a ListIt user, I want to create a collection from the sidebar, so that I can organize bookmarks while staying in the library.
+3. As a ListIt user, I want to rename a collection from the sidebar, so that I can correct or refine my organization.
+4. As a ListIt user, I want to delete a collection from the sidebar, so that I can remove organization I no longer need.
+5. As a ListIt user, I want deletion to keep bookmarks saved, so that removing a collection does not destroy my library.
+6. As a ListIt user, I want deletion to clearly warn me that bookmarks will become unassigned, so that I understand the effect before confirming.
+7. As a ListIt user, I want to filter the library by collection, so that I can focus on a specific set of bookmarks.
+8. As a ListIt user, I want to assign the selected bookmark to a collection from the details pane, so that organization happens close to the bookmark context.
+9. As a ListIt user, I want to clear a bookmark's collection assignment, so that bookmarks can return to an unassigned state.
+10. As a ListIt user, I want collection assignment to use real collection IDs, so that UI state persists correctly across reloads.
+11. As a ListIt user, I want empty collection states to feel clear and lightweight, so that a new workspace does not feel broken.
+
+## Implementation Decisions
+
+- Collection management lives inline in the existing sidebar Collections section.
+- Bookmark collection assignment lives in the selected-bookmark details pane.
+- Collection deletion requires a confirmation dialog.
+- Deleting a collection leaves bookmarks saved and clears their collection assignments through the existing backend behavior.
+- Filtering uses the selected collection ID and the existing bookmark list query.
+- Assignment uses the existing bookmark update mutation with a real collection ID or `null` for unassigned.
+- No schema changes are needed.
+- No new backend APIs are needed.
+- The UI should use existing shadcn-svelte components, current app shell patterns, and current design tokens.
+
+## Testing Decisions
+
+- Test external behavior through the app UI and existing Convex function contracts rather than implementation details.
+- Run Svelte autofixer on changed Svelte files.
+- Run `npm run check`.
+- Manually verify collection create, list, rename, delete, filtering, assignment, and clearing assignment.
+- Manually verify deleting a collection clears bookmark assignments while preserving bookmarks.
+
+## Out of Scope
+
+- Multi-collection bookmarks.
+- Drag-and-drop collection assignment.
+- Collection descriptions in the UI.
+- Collection counts.
+- Undo for collection deletion.
+- New search behavior.
+- Tag management changes.
+- Backend schema or API changes.
+
+## Further Notes
+
+This is an MVP integration pass. The smallest production-ready solution is to connect the existing backend to the current app shell without adding new abstractions or dependencies.

--- a/src/routes/(app)/app/+layout.svelte
+++ b/src/routes/(app)/app/+layout.svelte
@@ -2,12 +2,16 @@
 	import {
 		Archive03Icon,
 		BookOpen02Icon,
+		Delete02Icon,
+		Edit02Icon,
 		Folder01Icon,
 		HelpCircleIcon,
 		Home05Icon,
 		Loading03Icon,
 		Logout01Icon,
+		MoreHorizontalIcon,
 		NoteEditIcon,
+		PlusSignIcon,
 		Search01Icon,
 		Settings01Icon,
 		Tag01Icon,
@@ -20,7 +24,10 @@
 	import { onMount } from 'svelte';
 	import { useConvexClient, useQuery } from 'convex-svelte';
 	import { api } from '../../../convex/_generated/api.js';
+	import type { Doc } from '../../../convex/_generated/dataModel';
 	import { Button } from '$lib/components/ui/button';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { Input } from '$lib/components/ui/input';
 	import * as Separator from '$lib/components/ui/separator';
 	import * as Sidebar from '$lib/components/ui/sidebar';
@@ -35,8 +42,24 @@
 	let authReady = $state(false);
 	let isAuthenticated = $state(false);
 	let isSigningOut = $state(false);
+	let createCollectionOpen = $state(false);
+	let collectionName = $state('');
+	let collectionError = $state('');
+	let isSavingCollection = $state(false);
+	let editCollectionOpen = $state(false);
+	let editingCollection = $state<Doc<'collections'> | null>(null);
+	let editingName = $state('');
+	let editError = $state('');
+	let isUpdatingCollection = $state(false);
+	let deleteCollectionOpen = $state(false);
+	let deletingCollection = $state<Doc<'collections'> | null>(null);
+	let deleteError = $state('');
+	let isDeletingCollection = $state(false);
 
 	const currentUserResponse = useQuery(api.auth.currentUser, () =>
+		authReady && isAuthenticated ? {} : 'skip'
+	);
+	const collectionsResponse = useQuery(api.collections.list, () =>
 		authReady && isAuthenticated ? {} : 'skip'
 	);
 	const currentUser = $derived(currentUserResponse.data);
@@ -44,6 +67,8 @@
 	const userMeta = $derived(
 		currentUser?.email && currentUser?.name ? currentUser.email : 'ListIt account'
 	);
+	const collections = $derived((collectionsResponse.data ?? []) as Doc<'collections'>[]);
+	const selectedCollectionId = $derived(page.url.searchParams.get('collection'));
 
 	const primaryItems = [
 		{ href: '/app', label: 'Library', icon: Home05Icon },
@@ -52,7 +77,6 @@
 		{ href: '/app/settings', label: 'Settings', icon: Settings01Icon }
 	];
 
-	const collections = ['Reading queue', 'Product research', 'Frontend notes'];
 	const tags = ['AI', 'Svelte', 'Convex'];
 
 	onMount(() => {
@@ -84,6 +108,80 @@
 		isSigningOut = true;
 		await signOut(convexClient);
 		await goto(resolve('/'));
+	}
+
+	async function handleCreateCollection(event: SubmitEvent) {
+		event.preventDefault();
+		if (!convexClient) return;
+
+		const name = collectionName.trim();
+		if (!name) return;
+
+		isSavingCollection = true;
+		collectionError = '';
+
+		try {
+			await convexClient.mutation(api.collections.create, { name });
+			collectionName = '';
+			createCollectionOpen = false;
+		} catch (error) {
+			collectionError = error instanceof Error ? error.message : 'Could not create collection.';
+		} finally {
+			isSavingCollection = false;
+		}
+	}
+
+	function startEditingCollection(collection: Doc<'collections'>) {
+		editingCollection = collection;
+		editingName = collection.name;
+		editError = '';
+		editCollectionOpen = true;
+	}
+
+	async function handleRenameCollection(event: SubmitEvent) {
+		event.preventDefault();
+		if (!convexClient || !editingCollection) return;
+
+		const name = editingName.trim();
+		if (!name) return;
+
+		isUpdatingCollection = true;
+		editError = '';
+
+		try {
+			await convexClient.mutation(api.collections.update, {
+				collectionId: editingCollection._id,
+				name
+			});
+			editingCollection = null;
+			editingName = '';
+			editCollectionOpen = false;
+		} catch (error) {
+			editError = error instanceof Error ? error.message : 'Could not rename collection.';
+		} finally {
+			isUpdatingCollection = false;
+		}
+	}
+
+	async function handleDeleteCollection() {
+		if (!convexClient || !deletingCollection) return;
+
+		isDeletingCollection = true;
+		deleteError = '';
+
+		try {
+			const removedId = deletingCollection._id;
+			await convexClient.mutation(api.collections.remove, { collectionId: removedId });
+			deletingCollection = null;
+			deleteCollectionOpen = false;
+			if (selectedCollectionId === removedId) {
+				await goto(resolve('/app'));
+			}
+		} catch (error) {
+			deleteError = error instanceof Error ? error.message : 'Could not delete collection.';
+		} finally {
+			isDeletingCollection = false;
+		}
 	}
 </script>
 
@@ -144,17 +242,119 @@
 				<Sidebar.SidebarSeparator />
 
 				<Sidebar.SidebarGroup>
-					<Sidebar.SidebarGroupLabel>Collections</Sidebar.SidebarGroupLabel>
+					<div class="flex items-center justify-between gap-2 px-2">
+						<Sidebar.SidebarGroupLabel class="px-0">Collections</Sidebar.SidebarGroupLabel>
+						<Dialog.Dialog bind:open={createCollectionOpen}>
+							<Dialog.DialogTrigger>
+								<Button variant="ghost" size="icon-sm" class="size-6">
+									<HugeiconsIcon icon={PlusSignIcon} strokeWidth={2} class="size-3.5" />
+									<span class="sr-only">New collection</span>
+								</Button>
+							</Dialog.DialogTrigger>
+							<Dialog.DialogContent class="sm:max-w-sm">
+								<Dialog.DialogHeader>
+									<Dialog.DialogTitle>New collection</Dialog.DialogTitle>
+									<Dialog.DialogDescription>
+										Create a collection for organizing bookmarks.
+									</Dialog.DialogDescription>
+								</Dialog.DialogHeader>
+								<form class="space-y-3" onsubmit={handleCreateCollection}>
+									<Input
+										bind:value={collectionName}
+										placeholder="Collection name"
+										disabled={isSavingCollection}
+									/>
+									{#if collectionError}
+										<p class="text-xs text-destructive">{collectionError}</p>
+									{/if}
+									<Dialog.DialogFooter>
+										<Button
+											type="submit"
+											size="sm"
+											disabled={isSavingCollection || !collectionName.trim()}
+										>
+											{isSavingCollection ? 'Creating...' : 'Create'}
+										</Button>
+									</Dialog.DialogFooter>
+								</form>
+							</Dialog.DialogContent>
+						</Dialog.Dialog>
+					</div>
 					<Sidebar.SidebarGroupContent>
 						<Sidebar.SidebarMenu>
-							{#each collections as collection (collection)}
+							<Sidebar.SidebarMenuItem>
+								<Sidebar.SidebarMenuButton
+									size="sm"
+									isActive={!selectedCollectionId}
+									tooltipContent="All bookmarks"
+									onclick={() => goto(resolve('/app'))}
+								>
+									<HugeiconsIcon icon={Folder01Icon} strokeWidth={2} class="size-4" />
+									<span>All bookmarks</span>
+								</Sidebar.SidebarMenuButton>
+							</Sidebar.SidebarMenuItem>
+							{#if collectionsResponse.isLoading}
 								<Sidebar.SidebarMenuItem>
-									<Sidebar.SidebarMenuButton size="sm" tooltipContent={collection}>
-										<HugeiconsIcon icon={Folder01Icon} strokeWidth={2} class="size-4" />
-										<span>{collection}</span>
-									</Sidebar.SidebarMenuButton>
+									<div class="px-2 py-1.5 text-xs text-muted-foreground">
+										Loading collections...
+									</div>
 								</Sidebar.SidebarMenuItem>
-							{/each}
+							{:else if collections.length === 0}
+								<Sidebar.SidebarMenuItem>
+									<div class="px-2 py-1.5 text-xs text-muted-foreground">No collections yet</div>
+								</Sidebar.SidebarMenuItem>
+							{:else}
+								{#each collections as collection (collection._id)}
+									<Sidebar.SidebarMenuItem>
+										<div class="group/collection flex items-center gap-1">
+											<Sidebar.SidebarMenuButton
+												size="sm"
+												isActive={selectedCollectionId === collection._id}
+												tooltipContent={collection.name}
+												onclick={() => goto(resolve(`/app?collection=${collection._id}`))}
+											>
+												<HugeiconsIcon icon={Folder01Icon} strokeWidth={2} class="size-4" />
+												<span>{collection.name}</span>
+											</Sidebar.SidebarMenuButton>
+											<DropdownMenu.DropdownMenu>
+												<DropdownMenu.DropdownMenuTrigger>
+													<Button
+														variant="ghost"
+														size="icon-sm"
+														class="size-7 opacity-0 group-hover/collection:opacity-100 data-[state=open]:opacity-100"
+													>
+														<HugeiconsIcon
+															icon={MoreHorizontalIcon}
+															strokeWidth={2}
+															class="size-3.5"
+														/>
+														<span class="sr-only">Collection actions</span>
+													</Button>
+												</DropdownMenu.DropdownMenuTrigger>
+												<DropdownMenu.DropdownMenuContent class="w-36">
+													<DropdownMenu.DropdownMenuItem
+														onclick={() => startEditingCollection(collection)}
+													>
+														<HugeiconsIcon icon={Edit02Icon} strokeWidth={2} />
+														Rename
+													</DropdownMenu.DropdownMenuItem>
+													<DropdownMenu.DropdownMenuItem
+														variant="destructive"
+														onclick={() => {
+															deletingCollection = collection;
+															deleteError = '';
+															deleteCollectionOpen = true;
+														}}
+													>
+														<HugeiconsIcon icon={Delete02Icon} strokeWidth={2} />
+														Delete
+													</DropdownMenu.DropdownMenuItem>
+												</DropdownMenu.DropdownMenuContent>
+											</DropdownMenu.DropdownMenu>
+										</div>
+									</Sidebar.SidebarMenuItem>
+								{/each}
+							{/if}
 						</Sidebar.SidebarMenu>
 					</Sidebar.SidebarGroupContent>
 				</Sidebar.SidebarGroup>
@@ -197,7 +397,9 @@
 							</div>
 							<div class="grid flex-1 text-left leading-tight group-data-[collapsible=icon]:hidden">
 								<span class="truncate text-xs leading-tight font-medium">{userLabel}</span>
-								<span class="truncate text-[11px] leading-tight text-muted-foreground">{userMeta}</span>
+								<span class="truncate text-[11px] leading-tight text-muted-foreground"
+									>{userMeta}</span
+								>
 							</div>
 						</Sidebar.SidebarMenuButton>
 					</Sidebar.SidebarMenuItem>
@@ -241,3 +443,89 @@
 		</Sidebar.SidebarInset>
 	</Sidebar.Provider>
 {/if}
+
+<Dialog.Dialog
+	bind:open={editCollectionOpen}
+	onOpenChange={(open) => {
+		if (!open) editingCollection = null;
+	}}
+>
+	<Dialog.DialogContent class="sm:max-w-sm">
+		<Dialog.DialogHeader>
+			<Dialog.DialogTitle>Rename collection</Dialog.DialogTitle>
+			<Dialog.DialogDescription>Update the collection name.</Dialog.DialogDescription>
+		</Dialog.DialogHeader>
+		<form class="space-y-3" onsubmit={handleRenameCollection}>
+			<Input
+				bind:value={editingName}
+				placeholder="Collection name"
+				disabled={isUpdatingCollection}
+			/>
+			{#if editError}
+				<p class="text-xs text-destructive">{editError}</p>
+			{/if}
+			<Dialog.DialogFooter>
+				<Button
+					type="button"
+					variant="ghost"
+					size="sm"
+					onclick={() => {
+						editingCollection = null;
+						editCollectionOpen = false;
+					}}
+					disabled={isUpdatingCollection}
+				>
+					Cancel
+				</Button>
+				<Button type="submit" size="sm" disabled={isUpdatingCollection || !editingName.trim()}>
+					{isUpdatingCollection ? 'Saving...' : 'Save'}
+				</Button>
+			</Dialog.DialogFooter>
+		</form>
+	</Dialog.DialogContent>
+</Dialog.Dialog>
+
+<Dialog.Dialog
+	bind:open={deleteCollectionOpen}
+	onOpenChange={(open) => {
+		if (!open) deletingCollection = null;
+	}}
+>
+	<Dialog.DialogContent class="sm:max-w-sm">
+		<Dialog.DialogHeader>
+			<Dialog.DialogTitle>Delete collection?</Dialog.DialogTitle>
+			<Dialog.DialogDescription>
+				Bookmarks in this collection will stay saved and become unassigned.
+			</Dialog.DialogDescription>
+		</Dialog.DialogHeader>
+		{#if deletingCollection}
+			<p class="text-sm font-medium">{deletingCollection.name}</p>
+		{/if}
+		{#if deleteError}
+			<p class="text-xs text-destructive">{deleteError}</p>
+		{/if}
+		<Dialog.DialogFooter>
+			<Button
+				type="button"
+				variant="ghost"
+				size="sm"
+				onclick={() => {
+					deletingCollection = null;
+					deleteCollectionOpen = false;
+				}}
+				disabled={isDeletingCollection}
+			>
+				Cancel
+			</Button>
+			<Button
+				type="button"
+				variant="destructive"
+				size="sm"
+				onclick={handleDeleteCollection}
+				disabled={isDeletingCollection}
+			>
+				{isDeletingCollection ? 'Deleting...' : 'Delete'}
+			</Button>
+		</Dialog.DialogFooter>
+	</Dialog.DialogContent>
+</Dialog.Dialog>

--- a/src/routes/(app)/app/+layout.svelte
+++ b/src/routes/(app)/app/+layout.svelte
@@ -29,6 +29,7 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
 	import * as Separator from '$lib/components/ui/separator';
 	import * as Sidebar from '$lib/components/ui/sidebar';
 	import ThemeToggle from '$lib/components/theme-toggle.svelte';
@@ -251,23 +252,28 @@
 									<span class="sr-only">New collection</span>
 								</Button>
 							</Dialog.DialogTrigger>
-							<Dialog.DialogContent class="sm:max-w-sm">
+							<Dialog.DialogContent class="gap-3 text-xs sm:max-w-sm">
 								<Dialog.DialogHeader>
-									<Dialog.DialogTitle>New collection</Dialog.DialogTitle>
-									<Dialog.DialogDescription>
+									<Dialog.DialogTitle class="text-base">New collection</Dialog.DialogTitle>
+									<Dialog.DialogDescription class="text-xs leading-snug">
 										Create a collection for organizing bookmarks.
 									</Dialog.DialogDescription>
 								</Dialog.DialogHeader>
 								<form class="space-y-3" onsubmit={handleCreateCollection}>
-									<Input
-										bind:value={collectionName}
-										placeholder="Collection name"
-										disabled={isSavingCollection}
-									/>
+									<div class="space-y-1.5">
+										<Label for="new-collection-name" class="text-xs">Name</Label>
+										<Input
+											id="new-collection-name"
+											bind:value={collectionName}
+											placeholder="Reading queue"
+											disabled={isSavingCollection}
+											class="text-xs"
+										/>
+									</div>
 									{#if collectionError}
 										<p class="text-xs text-destructive">{collectionError}</p>
 									{/if}
-									<Dialog.DialogFooter>
+									<Dialog.DialogFooter class="gap-2">
 										<Button
 											type="submit"
 											size="sm"
@@ -450,21 +456,28 @@
 		if (!open) editingCollection = null;
 	}}
 >
-	<Dialog.DialogContent class="sm:max-w-sm">
+	<Dialog.DialogContent class="gap-3 text-xs sm:max-w-sm">
 		<Dialog.DialogHeader>
-			<Dialog.DialogTitle>Rename collection</Dialog.DialogTitle>
-			<Dialog.DialogDescription>Update the collection name.</Dialog.DialogDescription>
+			<Dialog.DialogTitle class="text-base">Rename collection</Dialog.DialogTitle>
+			<Dialog.DialogDescription class="text-xs leading-snug">
+				Update the collection name everywhere it appears.
+			</Dialog.DialogDescription>
 		</Dialog.DialogHeader>
 		<form class="space-y-3" onsubmit={handleRenameCollection}>
-			<Input
-				bind:value={editingName}
-				placeholder="Collection name"
-				disabled={isUpdatingCollection}
-			/>
+			<div class="space-y-1.5">
+				<Label for="edit-collection-name" class="text-xs">Name</Label>
+				<Input
+					id="edit-collection-name"
+					bind:value={editingName}
+					placeholder="Collection name"
+					disabled={isUpdatingCollection}
+					class="text-xs"
+				/>
+			</div>
 			{#if editError}
 				<p class="text-xs text-destructive">{editError}</p>
 			{/if}
-			<Dialog.DialogFooter>
+			<Dialog.DialogFooter class="gap-2">
 				<Button
 					type="button"
 					variant="ghost"
@@ -491,20 +504,25 @@
 		if (!open) deletingCollection = null;
 	}}
 >
-	<Dialog.DialogContent class="sm:max-w-sm">
+	<Dialog.DialogContent class="gap-3 text-xs sm:max-w-sm">
 		<Dialog.DialogHeader>
-			<Dialog.DialogTitle>Delete collection?</Dialog.DialogTitle>
-			<Dialog.DialogDescription>
+			<Dialog.DialogTitle class="text-base">Delete collection?</Dialog.DialogTitle>
+			<Dialog.DialogDescription class="text-xs leading-snug">
 				Bookmarks in this collection will stay saved and become unassigned.
 			</Dialog.DialogDescription>
 		</Dialog.DialogHeader>
 		{#if deletingCollection}
-			<p class="text-sm font-medium">{deletingCollection.name}</p>
+			<div class="rounded-lg border border-border/50 px-3 py-2">
+				<p class="truncate text-xs font-medium">{deletingCollection.name}</p>
+				<p class="mt-1 text-[11px] leading-snug text-muted-foreground">
+					This only removes the collection, not the bookmarks inside it.
+				</p>
+			</div>
 		{/if}
 		{#if deleteError}
 			<p class="text-xs text-destructive">{deleteError}</p>
 		{/if}
-		<Dialog.DialogFooter>
+		<Dialog.DialogFooter class="gap-2">
 			<Button
 				type="button"
 				variant="ghost"

--- a/src/routes/(app)/app/+page.svelte
+++ b/src/routes/(app)/app/+page.svelte
@@ -7,12 +7,14 @@
 		MagicWand01Icon,
 		NoteEditIcon,
 		PlusSignIcon,
-		SearchList01Icon
+		SearchList01Icon,
+		Folder01Icon
 	} from '@hugeicons/core-free-icons';
 	import { HugeiconsIcon } from '@hugeicons/svelte';
 	import { useConvexClient, useQuery } from 'convex-svelte';
+	import { page } from '$app/state';
 	import { api } from '../../../convex/_generated/api.js';
-	import type { Doc } from '../../../convex/_generated/dataModel';
+	import type { Doc, Id } from '../../../convex/_generated/dataModel';
 	import { Button } from '$lib/components/ui/button';
 	import * as Empty from '$lib/components/ui/empty';
 	import * as InputGroup from '$lib/components/ui/input-group';
@@ -28,13 +30,22 @@
 	};
 
 	const convexClient = useConvexClient();
-	const bookmarksResponse = useQuery(api.bookmarks.list, {});
+	const selectedCollectionId = $derived(
+		page.url.searchParams.get('collection') as Id<'collections'> | null
+	);
+	const bookmarksResponse = useQuery(api.bookmarks.list, () =>
+		selectedCollectionId ? { collectionId: selectedCollectionId } : {}
+	);
+	const collectionsResponse = useQuery(api.collections.list, {});
 	const rows = $derived((bookmarksResponse.data ?? []) as BookmarkRow[]);
+	const collections = $derived((collectionsResponse.data ?? []) as Doc<'collections'>[]);
 	let selectedBookmarkId = $state<string | null>(null);
 	let url = $state('');
 	let saveSuccess = $state('');
 	let saveError = $state('');
 	let isSaving = $state(false);
+	let assignmentError = $state('');
+	let isAssigningCollection = $state(false);
 
 	const selectedRow = $derived(
 		rows.find((row) => row.bookmark._id === selectedBookmarkId) ?? rows[0] ?? null
@@ -97,11 +108,28 @@
 			isSaving = false;
 		}
 	}
+
+	async function handleCollectionAssignment(value: string) {
+		if (!convexClient || !selectedRow) return;
+
+		const collectionId = value === 'unassigned' ? null : (value as Id<'collections'>);
+		isAssigningCollection = true;
+		assignmentError = '';
+
+		try {
+			await convexClient.mutation(api.bookmarks.update, {
+				bookmarkId: selectedRow.bookmark._id,
+				collectionId
+			});
+		} catch (error) {
+			assignmentError = error instanceof Error ? error.message : 'Could not update collection.';
+		} finally {
+			isAssigningCollection = false;
+		}
+	}
 </script>
 
-<div
-	class="flex h-[calc(100svh-3rem)] min-h-0 flex-col lg:grid lg:grid-cols-[minmax(0,1fr)_23rem]"
->
+<div class="flex h-[calc(100svh-3rem)] min-h-0 flex-col lg:grid lg:grid-cols-[minmax(0,1fr)_23rem]">
 	<section class="flex min-h-0 flex-col">
 		<div class="border-b border-border/50 px-4 py-3">
 			<div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
@@ -199,7 +227,9 @@
 							)}
 						>
 							<span class="min-w-0">
-								<span class="block truncate text-xs font-medium">{getDisplayTitle(row.bookmark)}</span>
+								<span class="block truncate text-xs font-medium"
+									>{getDisplayTitle(row.bookmark)}</span
+								>
 								<span class="mt-0.5 block truncate text-[11px] text-muted-foreground">
 									{row.bookmark.siteName || getHostname(row.bookmark.url)}
 									{#if row.collection}
@@ -235,7 +265,9 @@
 		{#if selectedRow}
 			<div class="border-b border-border/50 px-4 py-3">
 				<p class="text-[11px] font-medium text-muted-foreground uppercase">Selected bookmark</p>
-				<h2 class="mt-1.5 truncate text-base font-semibold">{getDisplayTitle(selectedRow.bookmark)}</h2>
+				<h2 class="mt-1.5 truncate text-base font-semibold">
+					{getDisplayTitle(selectedRow.bookmark)}
+				</h2>
 				<p class="mt-0.5 truncate text-xs text-muted-foreground">
 					{selectedRow.bookmark.siteName || getHostname(selectedRow.bookmark.url)}
 				</p>
@@ -272,6 +304,33 @@
 							placeholder="No note yet."
 							readonly
 						/>
+					</section>
+
+					<section>
+						<div class="flex items-center gap-2">
+							<HugeiconsIcon
+								icon={Folder01Icon}
+								strokeWidth={2}
+								class="size-3.5 text-muted-foreground"
+							/>
+							<h3 class="text-xs font-medium">Collection</h3>
+						</div>
+						<select
+							class="mt-2 h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-xs transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30"
+							value={selectedRow.bookmark.collectionId ?? 'unassigned'}
+							onchange={(event) => handleCollectionAssignment(event.currentTarget.value)}
+							disabled={isAssigningCollection || collectionsResponse.isLoading}
+						>
+							<option value="unassigned">Unassigned</option>
+							{#if collections.length}
+								{#each collections as collection (collection._id)}
+									<option value={collection._id}>{collection.name}</option>
+								{/each}
+							{/if}
+						</select>
+						{#if assignmentError}
+							<p class="mt-2 text-xs text-destructive">{assignmentError}</p>
+						{/if}
 					</section>
 
 					<section>


### PR DESCRIPTION
## Summary
- Add a PRD for the collections UI flow in `docs/lit-23-collections-ui-prd.md`.
- Replace placeholder sidebar collections with live Convex data and add inline create, rename, and delete flows.
- Add bookmark collection assignment in the details pane and support filtering the library by collection.
- Keep deletion behavior aligned with the backend so removing a collection clears bookmark assignments without deleting bookmarks.

## Testing
- Svelte autofixer passed on the changed `.svelte` files.
- `npm run check` passed.
- Verified the updated UI paths at a high level for collection CRUD, assignment, clearing assignment, and collection filtering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collections management: Create, rename, and delete collections
  * Bookmark organization: Assign bookmarks to collections or leave them unassigned
  * Improved sidebar navigation: Browse "All bookmarks" or select specific collections with dropdown actions for each
  * Error handling: Clear feedback when bookmark-to-collection assignment fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->