### PR TITLE
Refresh ListIt marketing pages for the new public experience

### DIFF
--- a/docs/ths-35-marketing-pages-brief.md
+++ b/docs/ths-35-marketing-pages-brief.md
@@ -1,0 +1,54 @@
+# THS-35 Marketing Pages Brief
+
+## Problem
+
+The current public marketing pages explain ListIt, but they rely on decorative effects and card-heavy product previews that drift from the Linear-inspired design system. THS-35 needs the marketing surface to feel modern, simple, and clear about the product.
+
+## Scope
+
+- Refresh the landing page at `/`.
+- Refresh the roadmap page at `/roadmap`.
+- Add a concise about page at `/about`.
+- Update public navigation for the added page.
+
+## Out Of Scope
+
+- Contact page or form.
+- Convex, auth, schema, and app workspace changes.
+- Global theme token changes.
+- New dependencies or reusable custom component abstractions.
+
+## Acceptance Criteria
+
+- Landing page communicates ListIt as bookmark memory in the first viewport.
+- Roadmap lists the MVP product phases in a compact design-system-compliant layout.
+- About page explains what ListIt is, who it is for, and what the MVP intentionally keeps small.
+- Public pages use tokenized colors, compact typography, subtle seams, and the continuous canvas.
+- Auth-aware CTA behavior remains unchanged.
+
+## Implementation Plan
+
+- Replace decorative public layout backgrounds with the plain tokenized canvas.
+- Add `About` to the public nav next to `Roadmap`.
+- Rebuild the landing page around a compact product message and flat workspace preview.
+- Rebuild the roadmap page as rows with status metadata instead of stacked cards.
+- Add `/about` with concise product context and no extra page chrome.
+
+## Files Likely To Change
+
+- `src/routes/(public)/+layout.svelte`
+- `src/routes/(public)/+page.svelte`
+- `src/routes/(public)/roadmap/+page.svelte`
+- `src/routes/(public)/about/+page.svelte`
+
+## Risks
+
+- The landing page must balance density with readability on mobile.
+- Public copy must stay practical and avoid overselling features that are not implemented yet.
+
+## Manual QA
+
+- Verify `/`, `/roadmap`, `/about`, `/login`, and `/signup` render in light and dark mode.
+- Confirm public nav active states for roadmap and about.
+- Confirm signed-in users see `Go to App`; signed-out users see sign-in/sign-up CTAs.
+- Confirm no decorative gradients, hardcoded colors, or card-heavy marketing sections were added.

--- a/src/routes/(public)/+layout.svelte
+++ b/src/routes/(public)/+layout.svelte
@@ -12,7 +12,10 @@
 
 	const convexUrl = import.meta.env.VITE_CONVEX_URL;
 	const convexClient = convexUrl ? useConvexClient() : null;
-	const navItems = [{ href: '/roadmap', label: 'Roadmap' }] as const;
+	const navItems = [
+		{ href: '/roadmap', label: 'Roadmap' },
+		{ href: '/about', label: 'About' }
+	] as const;
 	let signedIn = $state(false);
 
 	onMount(() => {
@@ -26,15 +29,6 @@
 </script>
 
 <div class="min-h-dvh bg-background text-foreground">
-	<div
-		aria-hidden="true"
-		class="pointer-events-none fixed inset-0 -z-10 bg-[linear-gradient(to_right,color-mix(in_oklch,var(--border)_50%,transparent)_1px,transparent_1px),linear-gradient(to_bottom,color-mix(in_oklch,var(--border)_40%,transparent)_1px,transparent_1px)] bg-[size:72px_72px] opacity-30"
-	></div>
-	<div
-		aria-hidden="true"
-		class="pointer-events-none fixed inset-x-0 top-0 -z-10 h-80 bg-[radial-gradient(circle_at_top,color-mix(in_oklch,var(--primary)_16%,transparent),transparent_60%)]"
-	></div>
-
 	<a
 		class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:rounded-md focus:bg-background focus:px-3 focus:py-2 focus:text-sm focus:shadow-sm"
 		href="#main-content"
@@ -55,8 +49,8 @@
 					{#each navItems as item (item.href)}
 						<a
 							class={cn(
-								'rounded-full px-3 py-2 text-sm text-muted-foreground transition-colors hover:text-foreground',
-								page.url.pathname === item.href && 'bg-muted text-foreground'
+								'rounded-full px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground',
+								page.url.pathname === item.href && 'bg-accent text-foreground'
 							)}
 							href={resolve(item.href)}
 							aria-current={page.url.pathname === item.href ? 'page' : undefined}

--- a/src/routes/(public)/+page.svelte
+++ b/src/routes/(public)/+page.svelte
@@ -15,39 +15,42 @@
 	const convexClient = convexUrl ? useConvexClient() : null;
 	let signedIn = $state(false);
 
-	const queue = [
+	const bookmarks = [
 		{
-			title: 'Design notes for route groups',
-			tag: 'Frontend',
-			state: 'enriched'
+			title: 'Research workflow notes',
+			source: 'linear.app',
+			status: 'enriched',
+			tag: 'Product'
+		},
+		{
+			title: 'SvelteKit route groups',
+			source: 'svelte.dev',
+			status: 'tagged',
+			tag: 'Frontend'
 		},
 		{
 			title: 'Convex auth setup',
-			tag: 'Product',
-			state: 'tagged'
-		},
-		{
-			title: 'Reader note draft',
-			tag: 'Personal',
-			state: 'pending'
+			source: 'convex.dev',
+			status: 'pending',
+			tag: 'Auth'
 		}
 	];
 
 	const features = [
 		{
 			title: 'Capture',
-			copy: 'Save a URL without breaking your flow.',
+			copy: 'Save a URL quickly and keep moving.',
 			icon: Link01Icon
 		},
 		{
-			title: 'Retrieve',
-			copy: 'Ask against saved links and get citations back.',
-			icon: SearchList01Icon
+			title: 'Organize',
+			copy: 'Use tags and collections only where they help.',
+			icon: NoteEditIcon
 		},
 		{
-			title: 'Refine',
-			copy: 'Keep one editable note next to the source.',
-			icon: NoteEditIcon
+			title: 'Ask',
+			copy: 'Get grounded answers that cite saved bookmarks.',
+			icon: SearchList01Icon
 		}
 	];
 
@@ -65,145 +68,100 @@
 	<title>ListIt</title>
 	<meta
 		name="description"
-		content="ListIt is a lightweight bookmark memory for saving links quickly, organizing them lightly, and asking grounded questions later."
+		content="ListIt is bookmark memory for saving links quickly, organizing them lightly, and asking grounded questions later."
 	/>
 </svelte:head>
 
-<section class="relative min-h-[calc(100dvh-3.5rem)] overflow-hidden">
+<section class="mx-auto flex min-h-[calc(100dvh-3.5rem)] w-full max-w-7xl px-4 sm:px-6 lg:px-8">
 	<div
-		aria-hidden="true"
-		class="absolute inset-0 bg-[linear-gradient(to_bottom,transparent,oklch(0.97_0.007_120_/_0.92)_82%,var(--background))] dark:bg-[linear-gradient(to_bottom,transparent,oklch(0.16_0.012_210_/_0.92)_82%,var(--background))]"
-	></div>
-
-	<div
-		class="relative mx-auto flex min-h-[calc(100dvh-3.5rem)] max-w-7xl flex-col justify-between px-4 pb-6 sm:px-6 lg:px-8"
+		class="grid w-full gap-8 py-8 lg:grid-cols-[minmax(0,28rem)_minmax(0,1fr)] lg:items-center lg:py-10"
 	>
-		<div
-			class="grid flex-1 gap-10 py-8 lg:grid-cols-[minmax(0,34rem)_minmax(0,1fr)] lg:items-center lg:py-10"
-		>
-			<div class="max-w-xl">
-				<p class="text-sm font-medium text-muted-foreground">Personal bookmark memory</p>
-				<h1 class="mt-4 font-heading text-5xl font-semibold text-balance sm:text-6xl">ListIt</h1>
-				<p class="mt-4 max-w-lg text-lg leading-7 text-pretty text-foreground/88">
-					Save links. Ask later. Keep just enough structure around the things you wanted to
-					remember.
-				</p>
-				<p class="mt-3 max-w-lg text-sm leading-6 text-pretty text-muted-foreground">
-					Built for solo use, keyboard-first capture, lightweight collections, and grounded answers
-					that still point back to the bookmark.
-				</p>
+		<div class="max-w-xl">
+			<p class="text-[11px] font-medium text-muted-foreground uppercase">Bookmark memory</p>
+			<h1 class="mt-3 font-heading text-xl font-semibold">ListIt</h1>
+			<p class="mt-4 max-w-lg text-sm leading-6 text-pretty text-muted-foreground">
+				Save links quickly, organize them lightly, and ask grounded questions later with answers
+				that point back to the source.
+			</p>
 
-				<div class="mt-7 flex flex-wrap items-center gap-3">
-					<Button href={signedIn ? '/app' : '/signup'} size="lg" class="rounded-full px-4">
-						{signedIn ? 'Go to App' : 'Create account'}
-						<HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} class="size-4" />
-					</Button>
-					<Button href="/roadmap" variant="outline" size="lg" class="rounded-full px-4">
-						View roadmap
-					</Button>
-				</div>
+			<div class="mt-6 flex flex-wrap items-center gap-2">
+				<Button href={signedIn ? '/app' : '/signup'}>
+					{signedIn ? 'Go to App' : 'Create account'}
+					<HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} class="size-4" />
+				</Button>
+				<Button href="/roadmap" variant="ghost">View roadmap</Button>
 			</div>
 
-			<div class="relative lg:pl-6">
-				<div
-					class="rounded-lg border border-border/70 bg-card/90 shadow-[0_24px_60px_-32px_rgba(15,23,42,0.4)] backdrop-blur"
-				>
-					<div class="flex items-center justify-between border-b border-border/70 px-4 py-3">
+			<div class="mt-8 grid gap-3 sm:grid-cols-3 lg:grid-cols-1">
+				{#each features as feature (feature.title)}
+					<div class="flex items-start gap-3 border-t border-border/60 pt-3">
+						<div class="mt-0.5 text-primary">
+							<HugeiconsIcon icon={feature.icon} strokeWidth={2} class="size-4" />
+						</div>
 						<div>
-							<p class="text-sm font-medium">Workspace preview</p>
-							<p class="text-xs text-muted-foreground">Tiny surface, grounded memory.</p>
-						</div>
-						<div class="inline-flex items-center gap-2 text-[11px] text-muted-foreground uppercase">
-							<span class="inline-flex items-center gap-1">
-								<span class="size-1.5 rounded-full bg-primary"></span>
-								live
-							</span>
+							<h2 class="text-sm font-medium">{feature.title}</h2>
+							<p class="mt-1 text-xs leading-5 text-muted-foreground">{feature.copy}</p>
 						</div>
 					</div>
-
-					<div class="grid lg:grid-cols-[15rem_minmax(0,1fr)]">
-						<div class="border-b border-border/70 px-4 py-4 lg:border-r lg:border-b-0">
-							<div class="rounded-lg border border-border/70 bg-background/70 px-3 py-2">
-								<p class="text-[11px] text-muted-foreground uppercase">Quick save</p>
-								<p class="mt-1 truncate text-sm">https://example.com/article</p>
-							</div>
-
-							<ul class="mt-4 space-y-2">
-								{#each queue as item (item.title)}
-									<li class="rounded-lg bg-background/70 px-3 py-2">
-										<div class="flex items-start justify-between gap-3">
-											<p class="text-sm leading-5 font-medium">{item.title}</p>
-											<span class="text-[11px] text-muted-foreground uppercase">{item.state}</span>
-										</div>
-										<p class="mt-1 text-xs text-muted-foreground">{item.tag}</p>
-									</li>
-								{/each}
-							</ul>
-						</div>
-
-						<div class="px-4 py-4">
-							<div class="grid gap-4 lg:grid-cols-[minmax(0,1fr)_13rem]">
-								<div>
-									<p class="text-[11px] text-muted-foreground uppercase">Reader note</p>
-									<h2 class="mt-2 text-base font-semibold">
-										One saved link becomes reusable context.
-									</h2>
-									<p class="mt-3 text-sm leading-6 text-muted-foreground">
-										Extraction stays in the background, notes stay editable, and the answer layer
-										stays tied to the source instead of improvising from nowhere.
-									</p>
-
-									<div class="mt-5 rounded-lg border border-border/70 bg-background/65 px-3 py-3">
-										<p class="text-[11px] text-muted-foreground uppercase">Ask my bookmarks</p>
-										<p class="mt-2 text-sm leading-6">
-											Route groups keep marketing and product routes separate, so public pages can
-											stay clean while the authenticated workspace grows behind them.
-										</p>
-										<p class="mt-2 text-[11px] text-muted-foreground">
-											Cites: Convex auth setup, Design notes for route groups
-										</p>
-									</div>
-								</div>
-
-								<div class="space-y-3">
-									<div class="rounded-lg border border-border/70 bg-background/70 px-3 py-3">
-										<p class="text-sm font-medium">Collections</p>
-										<p class="mt-1 text-xs text-muted-foreground">Frontend, Product, Personal</p>
-									</div>
-									<div class="rounded-lg border border-border/70 bg-background/70 px-3 py-3">
-										<p class="text-sm font-medium">Auto notes</p>
-										<p class="mt-1 text-xs text-muted-foreground">
-											Optional per bookmark after enrichment
-										</p>
-									</div>
-									<div class="rounded-lg border border-border/70 bg-background/70 px-3 py-3">
-										<p class="text-sm font-medium">Deduped capture</p>
-										<p class="mt-1 text-xs text-muted-foreground">
-											Normalized URLs keep the list calm
-										</p>
-									</div>
-								</div>
-							</div>
-						</div>
-					</div>
-				</div>
+				{/each}
 			</div>
 		</div>
 
-		<div class="grid gap-3 pb-2 sm:grid-cols-3">
-			{#each features as feature (feature.title)}
-				<div class="flex items-start gap-3 border-t border-border/60 pt-3">
-					<div class="mt-0.5 text-primary">
-						<HugeiconsIcon icon={feature.icon} strokeWidth={2} class="size-4" />
+		<div class="min-w-0 border-t border-border/60 pt-4 lg:border-t-0 lg:border-l lg:pt-0 lg:pl-8">
+			<div class="flex items-center justify-between gap-4 border-b border-border/60 pb-3">
+				<div>
+					<p class="text-sm font-medium">Workspace preview</p>
+					<p class="mt-1 text-xs text-muted-foreground">Capture, read, organize, and ask.</p>
+				</div>
+				<p class="text-[11px] text-muted-foreground uppercase">MVP</p>
+			</div>
+
+			<div class="grid gap-5 pt-4 xl:grid-cols-[16rem_minmax(0,1fr)]">
+				<div>
+					<div class="border-b border-border/60 pb-3">
+						<p class="text-[11px] text-muted-foreground uppercase">Quick save</p>
+						<p class="mt-1 truncate text-sm">https://example.com/article</p>
 					</div>
-					<div>
-						<p class="text-sm font-medium">{feature.title}</p>
-						<p class="mt-1 text-sm leading-6 text-pretty text-muted-foreground">
-							{feature.copy}
+
+					<ul class="mt-3 space-y-1">
+						{#each bookmarks as bookmark (bookmark.title)}
+							<li class="rounded-md px-2 py-2 transition-colors hover:bg-accent">
+								<div class="flex items-start justify-between gap-3">
+									<p class="min-w-0 truncate text-xs font-medium">{bookmark.title}</p>
+									<span class="shrink-0 text-[10px] text-muted-foreground uppercase">
+										{bookmark.status}
+									</span>
+								</div>
+								<p class="mt-1 truncate text-[11px] text-muted-foreground">
+									{bookmark.source} · {bookmark.tag}
+								</p>
+							</li>
+						{/each}
+					</ul>
+				</div>
+
+				<div
+					class="min-w-0 border-t border-border/60 pt-4 xl:border-t-0 xl:border-l xl:pt-0 xl:pl-5"
+				>
+					<p class="text-[11px] text-muted-foreground uppercase">Selected bookmark</p>
+					<h2 class="mt-2 text-base font-semibold">Research workflow notes</h2>
+					<p class="mt-3 max-w-xl text-sm leading-6 text-muted-foreground">
+						Reader text and one editable note stay beside the saved source, so useful context does
+						not disappear into another tab.
+					</p>
+
+					<div class="mt-5 border-t border-border/60 pt-4">
+						<p class="text-[11px] text-muted-foreground uppercase">Ask my bookmarks</p>
+						<p class="mt-2 max-w-xl text-sm leading-6">
+							ListIt can answer from saved links and keep the response tied to the bookmarks that
+							support it.
+						</p>
+						<p class="mt-2 text-[11px] text-muted-foreground">
+							Cites: Research workflow notes, SvelteKit route groups
 						</p>
 					</div>
 				</div>
-			{/each}
+			</div>
 		</div>
 	</div>
 </section>

--- a/src/routes/(public)/about/+page.svelte
+++ b/src/routes/(public)/about/+page.svelte
@@ -1,0 +1,46 @@
+<svelte:head>
+	<title>About | ListIt</title>
+	<meta
+		name="description"
+		content="About ListIt, a small bookmark memory for fast capture, light organization, and grounded retrieval."
+	/>
+</svelte:head>
+
+<section class="mx-auto min-h-[calc(100dvh-3.5rem)] max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+	<div class="grid gap-8 lg:grid-cols-[minmax(0,20rem)_minmax(0,1fr)] lg:items-start">
+		<div>
+			<p class="text-[11px] font-medium text-muted-foreground uppercase">About</p>
+			<h1 class="mt-3 font-heading text-xl font-semibold">A smaller way to remember links.</h1>
+			<p class="mt-3 max-w-md text-sm leading-6 text-muted-foreground">
+				ListIt is for solo users who save useful pages and want those pages to become searchable,
+				organized context later.
+			</p>
+		</div>
+
+		<div class="border-t border-border/60">
+			<div class="grid gap-3 border-b border-border/60 py-4 sm:grid-cols-[10rem_minmax(0,1fr)]">
+				<h2 class="text-base font-semibold">What it is</h2>
+				<p class="max-w-2xl text-sm leading-6 text-muted-foreground">
+					A private workspace for quick URL capture, manual tags and collections, reader notes, and
+					grounded answers over saved bookmarks.
+				</p>
+			</div>
+
+			<div class="grid gap-3 border-b border-border/60 py-4 sm:grid-cols-[10rem_minmax(0,1fr)]">
+				<h2 class="text-base font-semibold">Who it is for</h2>
+				<p class="max-w-2xl text-sm leading-6 text-muted-foreground">
+					People who collect research, references, product ideas, or articles and need a focused
+					place to find them again without building a large knowledge base.
+				</p>
+			</div>
+
+			<div class="grid gap-3 border-b border-border/60 py-4 sm:grid-cols-[10rem_minmax(0,1fr)]">
+				<h2 class="text-base font-semibold">What stays small</h2>
+				<p class="max-w-2xl text-sm leading-6 text-muted-foreground">
+					The MVP avoids teams, complex folder trees, multi-collection filing, document uploads, and
+					broad workspace automation. One saved link should stay easy to capture, read, and reuse.
+				</p>
+			</div>
+		</div>
+	</div>
+</section>

--- a/src/routes/(public)/roadmap/+page.svelte
+++ b/src/routes/(public)/roadmap/+page.svelte
@@ -2,23 +2,28 @@
 	const phases = [
 		{
 			name: 'Capture',
-			copy: 'Save a URL instantly and show it in the list before enrichment finishes.'
+			status: 'Current',
+			copy: 'Save a URL instantly and show it in the library before enrichment finishes.'
 		},
 		{
 			name: 'Organize',
-			copy: 'Use manual tags and collections without turning the app into a filing cabinet.'
+			status: 'Current',
+			copy: 'Use manual tags and one collection per bookmark for lightweight structure.'
 		},
 		{
 			name: 'Enrich',
-			copy: 'Fetch, extract, truncate, and suggest structure in the background.'
+			status: 'MVP',
+			copy: 'Extract readable text, truncate it for storage, and suggest useful organization.'
 		},
 		{
 			name: 'Ask',
-			copy: 'Retrieve the useful parts and answer with bookmark citations.'
+			status: 'MVP',
+			copy: 'Retrieve relevant bookmark context and answer with citations to saved links.'
 		},
 		{
 			name: 'Read',
-			copy: 'Keep editable notes next to extracted content so memory stays usable.'
+			status: 'MVP',
+			copy: 'Keep extracted content and one editable note close to the bookmark.'
 		}
 	];
 </script>
@@ -31,33 +36,32 @@
 	/>
 </svelte:head>
 
-<section class="mx-auto min-h-[calc(100dvh-3.5rem)] max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-	<div class="grid gap-10 lg:grid-cols-[minmax(0,24rem)_minmax(0,1fr)] lg:items-start">
-		<div class="lg:sticky lg:top-24">
-			<p class="text-sm font-medium text-muted-foreground">Roadmap</p>
-			<h1 class="mt-4 font-heading text-4xl font-semibold text-balance sm:text-5xl">
-				Five moves, then stop.
-			</h1>
-			<p class="mt-4 max-w-md text-base leading-7 text-pretty text-muted-foreground">
-				ListIt is deliberately small. The roadmap is about getting from saved link to useful
-				retrieval without turning the product into a life operating system.
+<section class="mx-auto min-h-[calc(100dvh-3.5rem)] max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+	<div class="grid gap-8 lg:grid-cols-[minmax(0,20rem)_minmax(0,1fr)] lg:items-start">
+		<div>
+			<p class="text-[11px] font-medium text-muted-foreground uppercase">Roadmap</p>
+			<h1 class="mt-3 font-heading text-xl font-semibold">Five MVP moves.</h1>
+			<p class="mt-3 max-w-md text-sm leading-6 text-muted-foreground">
+				ListIt stays small on purpose: capture links, add light structure, enrich content, ask
+				grounded questions, and read with notes.
 			</p>
 		</div>
 
-		<div class="space-y-3">
+		<div class="border-t border-border/60">
 			{#each phases as phase, index (phase.name)}
-				<div class="rounded-lg border border-border/70 bg-card/80 px-4 py-4 backdrop-blur sm:px-5">
-					<div class="grid gap-3 sm:grid-cols-[3rem_minmax(0,1fr)]">
-						<p class="text-sm text-muted-foreground tabular-nums">
-							{String(index + 1).padStart(2, '0')}
-						</p>
-						<div>
-							<h2 class="text-base font-semibold">{phase.name}</h2>
-							<p class="mt-1 text-sm leading-6 text-pretty text-muted-foreground">
-								{phase.copy}
-							</p>
-						</div>
+				<div
+					class="grid gap-3 border-b border-border/60 py-4 sm:grid-cols-[3rem_minmax(0,1fr)_5rem]"
+				>
+					<p class="text-[11px] text-muted-foreground tabular-nums">
+						{String(index + 1).padStart(2, '0')}
+					</p>
+					<div>
+						<h2 class="text-base font-semibold">{phase.name}</h2>
+						<p class="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">{phase.copy}</p>
 					</div>
+					<p class="text-[11px] font-medium text-muted-foreground uppercase sm:text-right">
+						{phase.status}
+					</p>
 				</div>
 			{/each}
 		</div>


### PR DESCRIPTION
## Summary
- Reworked the public marketing surface to match the Linear-inspired design system
- Simplified the landing page into a compact, first-viewport product pitch for bookmark memory
- Added an `/about` page and tightened `/roadmap` into a concise MVP overview
- Updated public navigation and removed decorative background effects that conflicted with the system
- Added a short implementation brief for THS-35

## Testing
- `svelte-autofixer` passed on all touched Svelte files
- `npm run check` passed
- Targeted Prettier and ESLint checks passed for the modified route files
- `npm run build` compiled successfully before failing at `adapter-vercel` due to the local Node.js version being `v25.8.1` instead of a supported runtime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added About page with product information and company mission
  * New navigation links to Roadmap and About pages
  * Updated feature highlights in homepage preview

* **Style**
  * Enhanced navigation active state styling
  * Redesigned preview data presentation format
  * Refreshed roadmap page layout with improved status display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->