### PR TITLE
Add authenticated app routes for Ask, Notes, and Settings

### DIFF
--- a/docs/ths-38-routing-setup-brief.md
+++ b/docs/ths-38-routing-setup-brief.md
@@ -1,0 +1,51 @@
+# THS-38 Routing Setup Brief
+
+## Problem
+
+The app shell links to primary workspace pages that do not exist yet, so users hit missing routes when navigating beyond the Library.
+
+## Scope
+
+- Keep Library at `/app`.
+- Add authenticated app routes for `/app/ask`, `/app/notes`, and `/app/settings`.
+- Render each page inside the existing app shell with lightweight structured placeholder content.
+- Make primary sidebar navigation use real links while preserving active states.
+
+## Out of scope
+
+- Convex schema or function changes.
+- Auth behavior changes.
+- Global theme or layout token changes.
+- Full Ask, Notes, or Settings feature implementation.
+
+## Acceptance criteria
+
+- `/app`, `/app/ask`, `/app/notes`, and `/app/settings` render in the app shell.
+- Sidebar primary nav links navigate to the real routes.
+- Active sidebar state reflects the current route.
+- Placeholder pages communicate MVP intent without fake backend behavior.
+- `npm run check` and `npm run lint` pass.
+
+## Implementation plan
+
+- Add route-local pages for Ask, Notes, and Settings.
+- Use existing UI primitives and Hugeicons already present in the app.
+- Update the sidebar primary menu buttons to render anchors through the existing `child` snippet API.
+
+## Files likely to change
+
+- `src/routes/(app)/app/+layout.svelte`
+- `src/routes/(app)/app/ask/+page.svelte`
+- `src/routes/(app)/app/notes/+page.svelte`
+- `src/routes/(app)/app/settings/+page.svelte`
+
+## Risks
+
+- Sidebar active matching should keep `/app` active only for Library, not for every child route.
+- Placeholder pages should stay visually useful without implying working backend features.
+
+## Manual QA
+
+- Visit `/app`, `/app/ask`, `/app/notes`, and `/app/settings`.
+- Click each sidebar primary nav item and confirm route navigation.
+- Check desktop and mobile widths for obvious overlap.

--- a/src/routes/(app)/app/+layout.svelte
+++ b/src/routes/(app)/app/+layout.svelte
@@ -88,7 +88,7 @@
 		{ href: '/app/ask', label: 'Ask', icon: Search01Icon },
 		{ href: '/app/notes', label: 'Notes', icon: NoteEditIcon },
 		{ href: '/app/settings', label: 'Settings', icon: Settings01Icon }
-	];
+	] as const;
 	type AppLibraryHref = '/app' | `/app?${string}`;
 
 	onMount(() => {
@@ -303,8 +303,12 @@
 										isActive={page.url.pathname === item.href}
 										tooltipContent={item.label}
 									>
-										<HugeiconsIcon icon={item.icon} strokeWidth={2} class="size-4" />
-										<span>{item.label}</span>
+										{#snippet child({ props })}
+											<a {...props} href={resolve(item.href)}>
+												<HugeiconsIcon icon={item.icon} strokeWidth={2} class="size-4" />
+												<span>{item.label}</span>
+											</a>
+										{/snippet}
 									</Sidebar.SidebarMenuButton>
 								</Sidebar.SidebarMenuItem>
 							{/each}

--- a/src/routes/(app)/app/ask/+page.svelte
+++ b/src/routes/(app)/app/ask/+page.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+	import {
+		ArrowRight01Icon,
+		Bookmark01Icon,
+		LinkSquare01Icon,
+		Search01Icon
+	} from '@hugeicons/core-free-icons';
+	import { HugeiconsIcon } from '@hugeicons/svelte';
+	import { Button } from '$lib/components/ui/button';
+	import * as Empty from '$lib/components/ui/empty';
+	import { Textarea } from '$lib/components/ui/textarea';
+</script>
+
+<svelte:head>
+	<title>Ask | ListIt</title>
+	<meta name="description" content="Ask questions grounded in your saved ListIt bookmarks." />
+</svelte:head>
+
+<main class="flex min-h-0 flex-1 flex-col">
+	<header class="border-b border-border/50 px-4 py-3">
+		<h1 class="font-heading text-xl font-semibold">Ask</h1>
+		<p class="mt-0.5 text-xs text-muted-foreground">
+			Ask across saved bookmarks and get answers grounded with citations.
+		</p>
+	</header>
+
+	<div class="grid min-h-0 flex-1 lg:grid-cols-[minmax(0,1fr)_20rem]">
+		<section class="flex min-h-0 flex-col px-4 py-4">
+			<div
+				class="flex min-h-0 flex-1 items-center justify-center rounded-md border border-dashed border-border/70 p-6"
+			>
+				<Empty.Empty class="border-0">
+					<Empty.EmptyHeader>
+						<Empty.EmptyMedia>
+							<HugeiconsIcon icon={Search01Icon} strokeWidth={2} />
+						</Empty.EmptyMedia>
+						<Empty.EmptyTitle>Ask is ready for routing</Empty.EmptyTitle>
+						<Empty.EmptyDescription>
+							Grounded answers will search enriched bookmark text and cite the saved links used.
+						</Empty.EmptyDescription>
+					</Empty.EmptyHeader>
+				</Empty.Empty>
+			</div>
+
+			<div class="mt-3 flex items-end gap-2">
+				<Textarea
+					class="min-h-20 resize-none text-xs"
+					placeholder="Ask a question about your saved links..."
+					disabled
+				/>
+				<Button class="mb-0.5 h-8" disabled>
+					Ask
+					<HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} data-icon="inline-end" />
+				</Button>
+			</div>
+		</section>
+
+		<aside class="hidden border-l border-border/50 lg:block">
+			<div class="border-b border-border/50 px-4 py-3">
+				<p class="text-[11px] font-medium text-muted-foreground uppercase">Answer context</p>
+				<p class="mt-1 text-xs text-muted-foreground">
+					Future retrieval inputs for grounded answers.
+				</p>
+			</div>
+			<div class="space-y-4 p-4">
+				<section>
+					<div class="flex items-center gap-2">
+						<HugeiconsIcon
+							icon={Bookmark01Icon}
+							strokeWidth={2}
+							class="size-3.5 text-muted-foreground"
+						/>
+						<h2 class="text-xs font-medium">Saved bookmarks</h2>
+					</div>
+					<p class="mt-2 text-xs leading-snug text-muted-foreground">
+						Enriched bookmark content will be searched before an answer is generated.
+					</p>
+				</section>
+				<section>
+					<div class="flex items-center gap-2">
+						<HugeiconsIcon
+							icon={LinkSquare01Icon}
+							strokeWidth={2}
+							class="size-3.5 text-muted-foreground"
+						/>
+						<h2 class="text-xs font-medium">Citations</h2>
+					</div>
+					<p class="mt-2 text-xs leading-snug text-muted-foreground">
+						Answers will point back to the source bookmarks that support the response.
+					</p>
+				</section>
+			</div>
+		</aside>
+	</div>
+</main>

--- a/src/routes/(app)/app/notes/+page.svelte
+++ b/src/routes/(app)/app/notes/+page.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+	import {
+		BookOpen02Icon,
+		Link01Icon,
+		NoteEditIcon,
+		PlusSignIcon
+	} from '@hugeicons/core-free-icons';
+	import { HugeiconsIcon } from '@hugeicons/svelte';
+	import { Button } from '$lib/components/ui/button';
+	import * as Empty from '$lib/components/ui/empty';
+	import { Textarea } from '$lib/components/ui/textarea';
+</script>
+
+<svelte:head>
+	<title>Notes | ListIt</title>
+	<meta name="description" content="Review and edit notes attached to saved ListIt bookmarks." />
+</svelte:head>
+
+<main class="flex min-h-0 flex-1 flex-col">
+	<header class="border-b border-border/50 px-4 py-3">
+		<div class="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+			<div>
+				<h1 class="font-heading text-xl font-semibold">Notes</h1>
+				<p class="mt-0.5 text-xs text-muted-foreground">
+					Review notes connected to saved links and keep useful context editable.
+				</p>
+			</div>
+			<Button size="sm" class="h-8 w-fit" disabled>
+				<HugeiconsIcon icon={PlusSignIcon} strokeWidth={2} data-icon="inline-start" />
+				New note
+			</Button>
+		</div>
+	</header>
+
+	<div class="grid min-h-0 flex-1 lg:grid-cols-[18rem_minmax(0,1fr)]">
+		<aside class="hidden border-r border-border/50 lg:block">
+			<div class="border-b border-border/50 px-4 py-3">
+				<p class="text-[11px] font-medium text-muted-foreground uppercase">Note sources</p>
+				<p class="mt-1 text-xs text-muted-foreground">Notes stay attached to bookmarks.</p>
+			</div>
+			<div class="space-y-2 p-2">
+				<div class="rounded-md px-2 py-2 text-xs text-muted-foreground">No bookmark notes yet.</div>
+			</div>
+		</aside>
+
+		<section class="flex min-h-0 flex-col px-4 py-4">
+			<div
+				class="flex min-h-56 items-center justify-center rounded-md border border-dashed border-border/70 p-6"
+			>
+				<Empty.Empty class="border-0">
+					<Empty.EmptyHeader>
+						<Empty.EmptyMedia>
+							<HugeiconsIcon icon={NoteEditIcon} strokeWidth={2} />
+						</Empty.EmptyMedia>
+						<Empty.EmptyTitle>No notes yet</Empty.EmptyTitle>
+						<Empty.EmptyDescription>
+							Saved bookmark notes will appear here for focused review and editing.
+						</Empty.EmptyDescription>
+					</Empty.EmptyHeader>
+				</Empty.Empty>
+			</div>
+
+			<div class="mt-4 grid gap-4 lg:grid-cols-2">
+				<section>
+					<div class="flex items-center gap-2">
+						<HugeiconsIcon
+							icon={BookOpen02Icon}
+							strokeWidth={2}
+							class="size-3.5 text-muted-foreground"
+						/>
+						<h2 class="text-xs font-medium">Reader notes</h2>
+					</div>
+					<Textarea
+						class="mt-2 min-h-32 resize-none text-xs"
+						placeholder="Select a bookmark note..."
+						disabled
+					/>
+				</section>
+				<section>
+					<div class="flex items-center gap-2">
+						<HugeiconsIcon
+							icon={Link01Icon}
+							strokeWidth={2}
+							class="size-3.5 text-muted-foreground"
+						/>
+						<h2 class="text-xs font-medium">Linked bookmark</h2>
+					</div>
+					<p class="mt-2 text-xs leading-snug text-muted-foreground">
+						Each note will keep its source link close so edits remain grounded in the saved page.
+					</p>
+				</section>
+			</div>
+		</section>
+	</div>
+</main>

--- a/src/routes/(app)/app/settings/+page.svelte
+++ b/src/routes/(app)/app/settings/+page.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+	import { Notification01Icon, Settings01Icon, UserCircle02Icon } from '@hugeicons/core-free-icons';
+	import { HugeiconsIcon } from '@hugeicons/svelte';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+</script>
+
+<svelte:head>
+	<title>Settings | ListIt</title>
+	<meta name="description" content="Manage ListIt account and workspace preferences." />
+</svelte:head>
+
+<main class="flex min-h-0 flex-1 flex-col">
+	<header class="border-b border-border/50 px-4 py-3">
+		<h1 class="font-heading text-xl font-semibold">Settings</h1>
+		<p class="mt-0.5 text-xs text-muted-foreground">
+			Manage account, workspace preferences, and future automation defaults.
+		</p>
+	</header>
+
+	<div class="grid min-h-0 flex-1 lg:grid-cols-[14rem_minmax(0,38rem)]">
+		<nav class="hidden border-r border-border/50 p-2 lg:block" aria-label="Settings sections">
+			<a
+				class="flex h-8 items-center gap-2 rounded-md bg-accent px-2 text-xs font-medium"
+				href="#account"
+			>
+				<HugeiconsIcon icon={UserCircle02Icon} strokeWidth={2} class="size-3.5" />
+				Account
+			</a>
+			<a
+				class="mt-1 flex h-8 items-center gap-2 rounded-md px-2 text-xs text-muted-foreground"
+				href="#workspace"
+			>
+				<HugeiconsIcon icon={Settings01Icon} strokeWidth={2} class="size-3.5" />
+				Workspace
+			</a>
+			<a
+				class="mt-1 flex h-8 items-center gap-2 rounded-md px-2 text-xs text-muted-foreground"
+				href="#notifications"
+			>
+				<HugeiconsIcon icon={Notification01Icon} strokeWidth={2} class="size-3.5" />
+				Notifications
+			</a>
+		</nav>
+
+		<section class="space-y-6 px-4 py-4">
+			<section id="account">
+				<div class="flex items-center gap-2">
+					<HugeiconsIcon
+						icon={UserCircle02Icon}
+						strokeWidth={2}
+						class="size-3.5 text-muted-foreground"
+					/>
+					<h2 class="text-base font-semibold">Account</h2>
+				</div>
+				<div class="mt-3 grid gap-3 sm:grid-cols-2">
+					<div class="space-y-1.5">
+						<Label for="settings-name" class="text-xs">Name</Label>
+						<Input id="settings-name" class="text-xs" placeholder="Signed-in user" disabled />
+					</div>
+					<div class="space-y-1.5">
+						<Label for="settings-email" class="text-xs">Email</Label>
+						<Input id="settings-email" class="text-xs" placeholder="user@example.com" disabled />
+					</div>
+				</div>
+			</section>
+
+			<section id="workspace" class="border-t border-border/50 pt-5">
+				<div class="flex items-center gap-2">
+					<HugeiconsIcon
+						icon={Settings01Icon}
+						strokeWidth={2}
+						class="size-3.5 text-muted-foreground"
+					/>
+					<h2 class="text-base font-semibold">Workspace</h2>
+				</div>
+				<p class="mt-2 text-xs leading-snug text-muted-foreground">
+					Default capture, enrichment, and note preferences will live here as those workflows ship.
+				</p>
+			</section>
+
+			<section id="notifications" class="border-t border-border/50 pt-5">
+				<div class="flex items-center gap-2">
+					<HugeiconsIcon
+						icon={Notification01Icon}
+						strokeWidth={2}
+						class="size-3.5 text-muted-foreground"
+					/>
+					<h2 class="text-base font-semibold">Notifications</h2>
+				</div>
+				<p class="mt-2 text-xs leading-snug text-muted-foreground">
+					Background enrichment and automation updates can be surfaced here later.
+				</p>
+			</section>
+
+			<div class="flex justify-end border-t border-border/50 pt-4">
+				<Button size="sm" class="h-8" disabled>Save changes</Button>
+			</div>
+		</section>
+	</div>
+</main>


### PR DESCRIPTION
## Summary
- Added a THS-38 implementation brief for the routing work.
- Created shell-ready authenticated pages for `/app/ask`, `/app/notes`, and `/app/settings`.
- Updated the primary sidebar navigation to use real SvelteKit links while preserving active state.
- Kept Library at `/app` and left Convex, auth, and global layout tokens untouched.

## Testing
- `npm run check` passed.
- Svelte autofixer passed on the touched Svelte files.
- Targeted Prettier and ESLint checks passed on the modified app files.
- Full repo lint was blocked by pre-existing formatting/parser issues in `.agents/skills` outside this change.