### PR TITLE
Implement background FireCrawl extraction for saved bookmarks

### DIFF
--- a/docs/ths-27-extraction-pipeline-brief.md
+++ b/docs/ths-27-extraction-pipeline-brief.md
@@ -1,0 +1,42 @@
+# THS-27 Extraction Pipeline Brief
+
+## Problem
+
+Saved bookmarks currently stop at `pending` extraction. ListIt needs real background URL extraction so saved links become reader-ready without blocking capture.
+
+## Scope
+
+- Schedule extraction immediately after creating a new bookmark.
+- Scrape the saved URL with FireCrawl.
+- Store truncated extracted markdown and metadata on the bookmark.
+- Record explicit enriched and failed states.
+- Let users retry failed extraction from the selected bookmark inspector.
+
+## Out of scope
+
+- Retrieval chunks and embeddings.
+- AI organization and auto-note generation.
+- Cron polling or a failed-bookmarks queue.
+- Schema changes or data migration.
+
+## Acceptance criteria
+
+- New bookmark saves return immediately and schedule background extraction.
+- Successful extraction writes text, metadata, `extractedAt`, and `extractionStatus: 'enriched'`.
+- Failed extraction writes `extractionStatus: 'failed'` and `extractionError`.
+- Retrying a failed bookmark marks it pending and schedules extraction again.
+- Deduped saves do not rerun extraction automatically.
+- `npm run check` passes.
+
+## Implementation plan
+
+- Add a Convex internal action that calls FireCrawl `scrape(url, { formats: ['markdown'], onlyMainContent: true })`.
+- Truncate stored markdown to `100_000` characters.
+- Reuse existing internal enrichment mutations for success and failure writes.
+- Update `bookmarks.saveUrl` to schedule extraction only for newly created bookmarks.
+- Add `bookmarks.retryExtraction` for owned bookmarks.
+- Add compact retry UI in the selected bookmark inspector when extraction failed.
+
+## Environment
+
+- `FIRECRAWL_API_KEY` must be set in the Convex deployment environment.

--- a/src/convex/_generated/api.d.ts
+++ b/src/convex/_generated/api.d.ts
@@ -12,6 +12,7 @@ import type * as auth from "../auth.js";
 import type * as bookmarks from "../bookmarks.js";
 import type * as collections from "../collections.js";
 import type * as enrichment from "../enrichment.js";
+import type * as extraction from "../extraction.js";
 import type * as helpers from "../helpers.js";
 import type * as http from "../http.js";
 import type * as tags from "../tags.js";
@@ -27,6 +28,7 @@ declare const fullApi: ApiFromModules<{
   bookmarks: typeof bookmarks;
   collections: typeof collections;
   enrichment: typeof enrichment;
+  extraction: typeof extraction;
   helpers: typeof helpers;
   http: typeof http;
   tags: typeof tags;

--- a/src/convex/bookmarks.ts
+++ b/src/convex/bookmarks.ts
@@ -1,5 +1,6 @@
 import { v } from 'convex/values';
 
+import { internal } from './_generated/api';
 import { mutation, query } from './_generated/server';
 import type { Doc, Id } from './_generated/dataModel';
 import type { QueryCtx } from './_generated/server';
@@ -73,7 +74,27 @@ export const saveUrl = mutation({
 			updatedAt: now,
 			lastSavedAt: now
 		});
+		await ctx.scheduler.runAfter(0, internal.extraction.processBookmark, { bookmarkId });
 		return { bookmarkId, created: true };
+	}
+});
+
+export const retryExtraction = mutation({
+	args: {
+		bookmarkId: v.id('bookmarks')
+	},
+	handler: async (ctx, args) => {
+		await requireOwnedBookmark(ctx, args.bookmarkId);
+		const now = Date.now();
+		await ctx.db.patch(args.bookmarkId, {
+			extractionStatus: 'pending',
+			extractionError: undefined,
+			updatedAt: now
+		});
+		await ctx.scheduler.runAfter(0, internal.extraction.processBookmark, {
+			bookmarkId: args.bookmarkId
+		});
+		return args.bookmarkId;
 	}
 });
 

--- a/src/convex/enrichment.ts
+++ b/src/convex/enrichment.ts
@@ -1,6 +1,6 @@
 import { v } from 'convex/values';
 
-import { internalMutation } from './_generated/server';
+import { internalMutation, internalQuery } from './_generated/server';
 
 const metadataValidator = {
 	title: v.optional(v.string()),
@@ -10,6 +10,17 @@ const metadataValidator = {
 	imageUrl: v.optional(v.string()),
 	canonicalUrl: v.optional(v.string())
 };
+
+export const getExtractionTarget = internalQuery({
+	args: {
+		bookmarkId: v.id('bookmarks')
+	},
+	handler: async (ctx, args) => {
+		const bookmark = await ctx.db.get(args.bookmarkId);
+		if (!bookmark) return null;
+		return { url: bookmark.normalizedUrl || bookmark.url };
+	}
+});
 
 export const saveExtractionSuccess = internalMutation({
 	args: {

--- a/src/convex/extraction.ts
+++ b/src/convex/extraction.ts
@@ -1,0 +1,79 @@
+'use node';
+
+import Firecrawl from '@mendable/firecrawl-js';
+import type { DocumentMetadata } from '@mendable/firecrawl-js';
+import { v } from 'convex/values';
+
+import { internal } from './_generated/api';
+import { internalAction } from './_generated/server';
+
+const MAX_EXTRACTED_TEXT_LENGTH = 100_000;
+
+function cleanOptionalText(value: unknown) {
+	return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function getExtractionError(error: unknown) {
+	if (error instanceof Error && error.message.trim()) {
+		return error.message;
+	}
+	return 'Extraction failed.';
+}
+
+function truncateExtractedText(text: string) {
+	return text.length > MAX_EXTRACTED_TEXT_LENGTH ? text.slice(0, MAX_EXTRACTED_TEXT_LENGTH) : text;
+}
+
+function metadataFromFirecrawl(metadata: DocumentMetadata | undefined) {
+	return {
+		title: cleanOptionalText(metadata?.title ?? metadata?.ogTitle),
+		description: cleanOptionalText(metadata?.description ?? metadata?.ogDescription),
+		siteName: cleanOptionalText(metadata?.ogSiteName),
+		faviconUrl: cleanOptionalText(metadata?.favicon),
+		imageUrl: cleanOptionalText(metadata?.ogImage),
+		canonicalUrl: cleanOptionalText(metadata?.ogUrl ?? metadata?.url ?? metadata?.sourceURL)
+	};
+}
+
+export const processBookmark = internalAction({
+	args: {
+		bookmarkId: v.id('bookmarks')
+	},
+	handler: async (ctx, args) => {
+		try {
+			const target: { url: string } | null = await ctx.runQuery(
+				internal.enrichment.getExtractionTarget,
+				{
+					bookmarkId: args.bookmarkId
+				}
+			);
+			if (!target) return;
+
+			if (!process.env.FIRECRAWL_API_KEY) {
+				throw new Error('FIRECRAWL_API_KEY is not configured.');
+			}
+
+			const firecrawl = new Firecrawl({ apiKey: process.env.FIRECRAWL_API_KEY });
+			const result = await firecrawl.scrape(target.url, {
+				formats: ['markdown'],
+				onlyMainContent: true
+			});
+			const extractedText = cleanOptionalText(result.markdown);
+
+			if (!extractedText) {
+				throw new Error('FireCrawl did not return extracted text.');
+			}
+
+			await ctx.runMutation(internal.enrichment.saveExtractionSuccess, {
+				bookmarkId: args.bookmarkId,
+				extractedText: truncateExtractedText(extractedText),
+				...metadataFromFirecrawl(result.metadata)
+			});
+		} catch (error) {
+			await ctx.runMutation(internal.enrichment.saveExtractionFailure, {
+				bookmarkId: args.bookmarkId,
+				error: getExtractionError(error)
+			});
+		}
+	}
+});

--- a/src/routes/(app)/app/+page.svelte
+++ b/src/routes/(app)/app/+page.svelte
@@ -11,7 +11,8 @@
 		SearchList01Icon,
 		Folder01Icon,
 		Tag01Icon,
-		Delete02Icon
+		Delete02Icon,
+		RefreshIcon
 	} from '@hugeicons/core-free-icons';
 	import { HugeiconsIcon } from '@hugeicons/svelte';
 	import { useConvexClient, useQuery } from 'convex-svelte';
@@ -69,6 +70,8 @@
 	let isTagInputFocused = $state(false);
 	let highlightedTagOptionIndex = $state(0);
 	let isInspectorOpen = $state(true);
+	let retryError = $state('');
+	let retryingBookmarkId = $state<string | null>(null);
 
 	const selectedRow = $derived(
 		rows.find((row) => row.bookmark._id === selectedBookmarkId) ?? rows[0] ?? null
@@ -98,6 +101,16 @@
 			bookmark.extractedText?.trim().slice(0, 320) ||
 			'Extraction has not added reader text for this bookmark yet.'
 		);
+	}
+
+	function getExtractionContext(bookmark: Doc<'bookmarks'>) {
+		if (bookmark.extractionStatus === 'enriched') {
+			return 'Extracted text is ready for grounded answers.';
+		}
+		if (bookmark.extractionStatus === 'failed') {
+			return bookmark.extractionError || 'Extraction failed. Retry when you are ready.';
+		}
+		return 'This bookmark becomes stronger context after enrichment finishes.';
 	}
 
 	function getTags(row: BookmarkRow) {
@@ -273,6 +286,23 @@
 			tagError = error instanceof Error ? error.message : 'Could not update tags.';
 		} finally {
 			isSavingTags = false;
+		}
+	}
+
+	async function handleRetryExtraction() {
+		if (!convexClient || !selectedRow) return;
+
+		retryingBookmarkId = selectedRow.bookmark._id;
+		retryError = '';
+
+		try {
+			await convexClient.mutation(api.bookmarks.retryExtraction, {
+				bookmarkId: selectedRow.bookmark._id
+			});
+		} catch (error) {
+			retryError = error instanceof Error ? error.message : 'Could not retry extraction.';
+		} finally {
+			retryingBookmarkId = null;
 		}
 	}
 </script>
@@ -593,10 +623,26 @@
 							<h3 class="text-xs font-medium">Ask context</h3>
 						</div>
 						<p class="mt-2 text-xs leading-snug text-muted-foreground">
-							{selectedRow.bookmark.extractionStatus === 'enriched'
-								? 'Extracted text is ready for grounded answers.'
-								: 'This bookmark becomes stronger context after enrichment finishes.'}
+							{getExtractionContext(selectedRow.bookmark)}
 						</p>
+						{#if selectedRow.bookmark.extractionStatus === 'failed'}
+							<Button
+								type="button"
+								variant="ghost"
+								size="sm"
+								class="mt-2 h-8 px-0 text-xs"
+								onclick={handleRetryExtraction}
+								disabled={retryingBookmarkId === selectedRow.bookmark._id}
+							>
+								{retryingBookmarkId === selectedRow.bookmark._id
+									? 'Retrying...'
+									: 'Retry extraction'}
+								<HugeiconsIcon icon={RefreshIcon} strokeWidth={2} data-icon="inline-end" />
+							</Button>
+							{#if retryError}
+								<p class="mt-2 text-xs text-destructive">{retryError}</p>
+							{/if}
+						{/if}
 						<Button variant="ghost" size="sm" class="mt-2 h-8 px-0 text-xs">
 							Ask with this bookmark
 							<HugeiconsIcon icon={ArrowRight01Icon} strokeWidth={2} data-icon="inline-end" />


### PR DESCRIPTION
## Summary
- Added a Convex background extraction action that scrapes saved URLs with FireCrawl, truncates extracted markdown, and writes metadata back through the existing enrichment mutations.
- Scheduled extraction immediately when a new bookmark is created and added `bookmarks.retryExtraction` for failed bookmarks.
- Added compact retry handling in the selected bookmark inspector and created a short implementation brief for the ticket.

## Testing
- `npm run check` passed.
- Targeted Prettier checks on the touched files passed.
- Convex codegen was regenerated for the new `extraction` module.
- `npm run build` reached the app build, then failed on the local Node `v25.8.1` / Vercel adapter runtime restriction.
- `npm run lint` was not clean because the repo already has widespread Prettier issues outside this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now retry content extraction for bookmarks that failed during initial processing
  * Enhanced metadata capture including page title, description, site name, favicon, image, and canonical URL information
  * Improved extraction status indicators with clearer feedback on bookmark processing results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->